### PR TITLE
Data format descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 ## Unreleased
 
 Initial release under new ownership.
+- Added support for Data Format Descriptor parsing (Rob Swain [@superdump](https://github.com/superdump))
 
 ### Changed
 - Cleaned up a signifigant portion of the crate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ exclude = [
 default = ["std"]
 std = []
 
+[dependencies]
+bitflags = "1.3.2"
+
 [package.metadata.release]
 pre-release-hook = ["cargo", "readme", "-o", "README.md", "-t", "README.tpl"]
 [[package.metadata.release.pre-release-replacements]]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Parser for the [ktx2](https://github.khronos.org/KTX-Specification/) texture con
 - [x] Async reading
 - [x] Parsing
 - [x] Validating
-- [ ] [Data format description](https://github.khronos.org/KTX-Specification/#_data_format_descriptor)
+- [x] [Data format description](https://github.khronos.org/KTX-Specification/#_data_format_descriptor)
 - [ ] [Key/value data](https://github.khronos.org/KTX-Specification/#_keyvalue_data)
 
 License: Apache-2.0

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -198,3 +198,76 @@ pseudo_enum! {
         ZLIB = 3,
     }
 }
+
+pseudo_enum! {
+    ColorModel {
+        RGBSDA = 1,
+        YUVSDA = 2,
+        YIQSDA = 3,
+        LabSDA = 4,
+        CMYKA = 5,
+        XYZW = 6,
+        HSVAAng = 7,
+        HSLAAng = 8,
+        HSVAHex = 9,
+        HSLAHex = 10,
+        YCgCoA = 11,
+        YcCbcCrc = 12,
+        ICtCp = 13,
+        CIEXYZ = 14,
+        CIEXYY = 15,
+        BC1A = 128,
+        BC2 = 129,
+        BC3 = 130,
+        BC4 = 131,
+        BC5 = 132,
+        BC6H = 133,
+        BC7 = 134,
+        ETC1 = 160,
+        ETC2 = 161,
+        ASTC = 162,
+        ETC1S = 163,
+        PVRTC = 164,
+        PVRTC2 = 165,
+        UASTC = 166,
+    }
+}
+
+pseudo_enum! {
+    ColorPrimaries {
+        BT709 = 1,
+        BT601EBU = 2,
+        BT601SMPTE = 3,
+        BT2020 = 4,
+        CIEXYZ = 5,
+        ACES = 6,
+        ACESCC = 7,
+        NTSC1953 = 8,
+        PAL525 = 9,
+        DISPLAYP3 = 10,
+        AdobeRGB = 11,
+    }
+}
+
+pseudo_enum! {
+    TransferFunction {
+        Linear = 1,
+        SRGB = 2,
+        ITU = 3,
+        NTSC = 4,
+        SLOG = 5,
+        SLOG2 = 6,
+        BT1886 = 7,
+        HLGOETF = 8,
+        HLGEOTF = 9,
+        PQEOTF = 10,
+        PQOETF = 11,
+        DCIP3 = 12,
+        PALOETF = 13,
+        PAL625EOTF = 14,
+        ST240 = 15,
+        ACESCC = 16,
+        ACESCCT = 17,
+        AdobeRGB = 18,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,7 +452,7 @@ impl From<u32> for ColorModel {
             164 => Self::PVRTC,
             165 => Self::PVRTC2,
             166 => Self::UASTC,
-            0 | _ => Self::Unspecified,
+            _ => Self::Unspecified,
         }
     }
 }
@@ -499,7 +499,7 @@ impl From<u32> for ColorPrimaries {
             9 => Self::PAL525,
             10 => Self::DISPLAYP3,
             11 => Self::AdobeRGB,
-            0 | _ => Self::Unspecified,
+            _ => Self::Unspecified,
         }
     }
 }
@@ -554,7 +554,7 @@ impl From<u32> for TransferFunction {
             16 => Self::ACESCC,
             17 => Self::ACESCCT,
             18 => Self::AdobeRGB,
-            0 | _ => Self::Unspecified,
+            _ => Self::Unspecified,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,8 +216,6 @@ bitflags::bitflags! {
         const EXPONENT      = (1 << 1);
         const SIGNED        = (1 << 2);
         const FLOAT         = (1 << 3);
-        const NONE          = 0;
-        const UNINITIALIZED = 0xFFFF;
     }
 }
 
@@ -225,9 +223,8 @@ bitflags::bitflags! {
     #[derive(Default)]
     #[repr(transparent)]
     pub struct DataFormatFlags: u32 {
+        const STRAIGHT_ALPHA             = 0;
         const ALPHA_PREMULTIPLIED        = (1 << 0);
-        const NONE          = 0;
-        const UNINITIALIZED = 0xFFFF;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         let header = self.header();
         let start = header.sgd_byte_offset as usize;
         let end = (header.sgd_byte_offset + header.sgd_byte_length) as usize;
-        self.input.as_ref()[start..end].try_into().unwrap()
+        &self.input.as_ref()[start..end]
     }
 
     pub fn data_format_descriptors(&self) -> impl Iterator<Item = BasicDataFormatDescriptor> {
@@ -263,7 +263,7 @@ pub struct BasicDataFormatDescriptor<'data> {
 }
 
 impl<'data> BasicDataFormatDescriptor<'data> {
-    pub fn from_bytes_and_offset(bytes: &'data [u8], initial_offset: usize) -> Self {
+    fn from_bytes_and_offset(bytes: &'data [u8], initial_offset: usize) -> Self {
         let mut offset = initial_offset;
 
         let v = bytes_to_u32(bytes, &mut offset);
@@ -360,7 +360,7 @@ pub struct SampleInformation {
 impl SampleInformation {
     const LENGTH: usize = 16;
 
-    pub fn from_bytes(bytes: &[u8]) -> Self {
+    fn from_bytes(bytes: &[u8]) -> Self {
         let mut offset = 0;
 
         let v = bytes_to_u32(bytes, &mut offset);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,19 +246,19 @@ const F32_1_AS_U32: u32 = 1065353216;
 
 #[derive(Debug, Default)]
 pub struct BasicDataFormatDescriptor {
-    pub vendor_id: u32,                              //: 17;
-    pub descriptor_type: u32,                        //: 15;
-    pub version_number: u32,                         //: 16;
-    pub descriptor_block_size: u32,                  //: 16;
+    pub vendor_id: u32,             //: 17;
+    pub descriptor_type: u32,       //: 15;
+    pub version_number: u32,        //: 16;
+    pub descriptor_block_size: u32, //: 16;
     /// None means Unspecified or is an otherwise unknown value
-    pub color_model: Option<ColorModel>,             //: 8;
+    pub color_model: Option<ColorModel>, //: 8;
     /// None means Unspecified or is an otherwise unknown value
-    pub color_primaries: Option<ColorPrimaries>,     //: 8;
+    pub color_primaries: Option<ColorPrimaries>, //: 8;
     /// None means Unspecified or is an otherwise unknown value
     pub transfer_function: Option<TransferFunction>, //: 8;
-    pub flags: DataFormatFlags,                      //: 8;
-    pub texel_block_dimensions: [u32; 4],            //: 8 x 4;
-    pub bytes_planes: [u32; 8],                      //: 8 x 8;
+    pub flags: DataFormatFlags,     //: 8;
+    pub texel_block_dimensions: [u32; 4], //: 8 x 4;
+    pub bytes_planes: [u32; 8],     //: 8 x 8;
     samples_offset: usize,
     samples_end: usize,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,41 +388,43 @@ impl SampleInformation {
 
 #[derive(Debug)]
 pub enum ColorModel {
-    Unspecified = 0,
-    RGBSDA = 1,
-    YUVSDA = 2,
-    YIQSDA = 3,
-    LabSDA = 4,
-    CMYKA = 5,
-    XYZW = 6,
-    HSVAAng = 7,
-    HSLAAng = 8,
-    HSVAHex = 9,
-    HSLAHex = 10,
-    YCgCoA = 11,
-    YcCbcCrc = 12,
-    ICtCp = 13,
-    CIEXYZ = 14,
-    CIEXYY = 15,
-    BC1A = 128,
-    BC2 = 129,
-    BC3 = 130,
-    BC4 = 131,
-    BC5 = 132,
-    BC6H = 133,
-    BC7 = 134,
-    ETC1 = 160,
-    ETC2 = 161,
-    ASTC = 162,
-    ETC1S = 163,
-    PVRTC = 164,
-    PVRTC2 = 165,
-    UASTC = 166,
+    Unspecified, // 0
+    RGBSDA,      // 1
+    YUVSDA,      // 2
+    YIQSDA,      // 3
+    LabSDA,      // 4
+    CMYKA,       // 5
+    XYZW,        // 6
+    HSVAAng,     // 7
+    HSLAAng,     // 8
+    HSVAHex,     // 9
+    HSLAHex,     // 10
+    YCgCoA,      // 11
+    YcCbcCrc,    // 12
+    ICtCp,       // 13
+    CIEXYZ,      // 14
+    CIEXYY,      // 15
+    BC1A,        // 128
+    BC2,         // 129
+    BC3,         // 130
+    BC4,         // 131
+    BC5,         // 132
+    BC6H,        // 133
+    BC7,         // 134
+    ETC1,        // 160
+    ETC2,        // 161
+    ASTC,        // 162
+    ETC1S,       // 163
+    PVRTC,       // 164
+    PVRTC2,      // 165
+    UASTC,       // 166
+    Unknown(u32),
 }
 
 impl From<u32> for ColorModel {
     fn from(color_model: u32) -> Self {
         match color_model {
+            0 => Self::Unspecified,
             1 => Self::RGBSDA,
             2 => Self::YUVSDA,
             3 => Self::YIQSDA,
@@ -452,7 +454,7 @@ impl From<u32> for ColorModel {
             164 => Self::PVRTC,
             165 => Self::PVRTC2,
             166 => Self::UASTC,
-            _ => Self::Unspecified,
+            v => Self::Unknown(v),
         }
     }
 }
@@ -465,18 +467,19 @@ impl Default for ColorModel {
 
 #[derive(Debug)]
 pub enum ColorPrimaries {
-    Unspecified = 0,
-    BT709 = 1,
-    BT601EBU = 2,
-    BT601SMPTE = 3,
-    BT2020 = 4,
-    CIEXYZ = 5,
-    ACES = 6,
-    ACESCC = 7,
-    NTSC1953 = 8,
-    PAL525 = 9,
-    DISPLAYP3 = 10,
-    AdobeRGB = 11,
+    Unspecified, // 0
+    BT709,       // 1
+    BT601EBU,    // 2
+    BT601SMPTE,  // 3
+    BT2020,      // 4
+    CIEXYZ,      // 5
+    ACES,        // 6
+    ACESCC,      // 7
+    NTSC1953,    // 8
+    PAL525,      // 9
+    DISPLAYP3,   // 10
+    AdobeRGB,    // 11
+    Unknown(u32),
 }
 
 impl Default for ColorPrimaries {
@@ -488,6 +491,7 @@ impl Default for ColorPrimaries {
 impl From<u32> for ColorPrimaries {
     fn from(color_primaries: u32) -> Self {
         match color_primaries {
+            0 => Self::Unspecified,
             1 => Self::BT709,
             2 => Self::BT601EBU,
             3 => Self::BT601SMPTE,
@@ -499,32 +503,33 @@ impl From<u32> for ColorPrimaries {
             9 => Self::PAL525,
             10 => Self::DISPLAYP3,
             11 => Self::AdobeRGB,
-            _ => Self::Unspecified,
+            v => Self::Unknown(v),
         }
     }
 }
 
 #[derive(Debug)]
 pub enum TransferFunction {
-    Unspecified = 0,
-    Linear = 1,
-    SRGB = 2,
-    ITU = 3,
-    NTSC = 4,
-    SLOG = 5,
-    SLOG2 = 6,
-    BT1886 = 7,
-    HLGOETF = 8,
-    HLGEOTF = 9,
-    PQEOTF = 10,
-    PQOETF = 11,
-    DCIP3 = 12,
-    PALOETF = 13,
-    PAL625EOTF = 14,
-    ST240 = 15,
-    ACESCC = 16,
-    ACESCCT = 17,
-    AdobeRGB = 18,
+    Unspecified, // 0
+    Linear,      // 1
+    SRGB,        // 2
+    ITU,         // 3
+    NTSC,        // 4
+    SLOG,        // 5
+    SLOG2,       // 6
+    BT1886,      // 7
+    HLGOETF,     // 8
+    HLGEOTF,     // 9
+    PQEOTF,      // 10
+    PQOETF,      // 11
+    DCIP3,       // 12
+    PALOETF,     // 13
+    PAL625EOTF,  // 14
+    ST240,       // 15
+    ACESCC,      // 16
+    ACESCCT,     // 17
+    AdobeRGB,    // 18
+    Unknown(u32),
 }
 
 impl Default for TransferFunction {
@@ -536,6 +541,7 @@ impl Default for TransferFunction {
 impl From<u32> for TransferFunction {
     fn from(transfer_function: u32) -> Self {
         match transfer_function {
+            0 => Self::Unspecified,
             1 => Self::Linear,
             2 => Self::SRGB,
             3 => Self::ITU,
@@ -554,7 +560,7 @@ impl From<u32> for TransferFunction {
             16 => Self::ACESCC,
             17 => Self::ACESCCT,
             18 => Self::AdobeRGB,
-            _ => Self::Unspecified,
+            v => Self::Unknown(v),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,14 @@
 
 #![no_std]
 
+extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
 mod enums;
 mod error;
+
+use alloc::vec::Vec;
 
 pub use crate::{
     enums::{Format, SupercompressionScheme},
@@ -44,13 +47,13 @@ pub struct Reader<Data: AsRef<[u8]>> {
 impl<Data: AsRef<[u8]>> Reader<Data> {
     /// Decode KTX2 data from `input`
     pub fn new(input: Data) -> Result<Self, ParseError> {
-        if input.as_ref().len() < 48 {
+        if input.as_ref().len() < Header::LENGTH {
             return Err(ParseError::UnexpectedEnd);
         }
         if !input.as_ref().starts_with(&KTX2_MAGIC) {
             return Err(ParseError::BadMagic);
         }
-        let header = input.as_ref()[0..48].try_into().unwrap();
+        let header = input.as_ref()[0..Header::LENGTH].try_into().unwrap();
         Header::from_bytes(header).validate()?;
 
         let result = Self { input };
@@ -66,18 +69,16 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
     }
 
     fn level_index(&self) -> ParseResult<impl ExactSizeIterator<Item = LevelIndex> + '_> {
-        const LEVEL_INDEX_START_BYTE: usize = 80;
-        const LEVEL_INDEX_BYTE_LEN: usize = 24;
         let level_count = self.header().level_count.max(1) as usize;
 
-        let level_index_end_byte = LEVEL_INDEX_START_BYTE + level_count * LEVEL_INDEX_BYTE_LEN;
+        let level_index_end_byte = Header::LENGTH + level_count * LevelIndex::LENGTH;
         let level_index_bytes = self
             .input
             .as_ref()
-            .get(LEVEL_INDEX_START_BYTE..level_index_end_byte)
+            .get(Header::LENGTH..level_index_end_byte)
             .ok_or(ParseError::UnexpectedEnd)?;
         Ok(level_index_bytes
-            .chunks_exact(LEVEL_INDEX_BYTE_LEN)
+            .chunks_exact(LevelIndex::LENGTH)
             .map(LevelIndex::from_bytes))
     }
 
@@ -88,7 +89,7 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
 
     /// Container-level metadata
     pub fn header(&self) -> Header {
-        let bytes = self.input.as_ref()[0..48].try_into().unwrap();
+        let bytes = self.input.as_ref()[0..Header::LENGTH].try_into().unwrap();
         Header::from_bytes(bytes)
     }
 
@@ -97,6 +98,35 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         self.level_index()
             .unwrap()
             .map(move |level| &self.input.as_ref()[level.offset as usize..(level.offset + level.length_bytes) as usize])
+    }
+
+    pub fn supercompression_global_data(&self) -> &[u8] {
+        let header = self.header();
+        let start = header.sgd_byte_offset as usize;
+        let end = (header.sgd_byte_offset + header.sgd_byte_length) as usize;
+        self.input.as_ref()[start..end].try_into().unwrap()
+    }
+
+    pub fn data_format_descriptors(&self) -> Vec<BasicDataFormatDescriptor> {
+        let header = self.header();
+        let start = header.dfd_byte_offset as usize;
+        let length: u32 = u32::from_le_bytes(self.input.as_ref()[start..start + 4].try_into().unwrap());
+        assert_eq!(length, header.dfd_byte_length);
+        assert_eq!(length, header.kvd_byte_offset - header.dfd_byte_offset);
+        let end = (header.dfd_byte_offset + header.dfd_byte_length) as usize;
+        let dfd_data: &[u8] = self.input.as_ref()[start..end].try_into().unwrap();
+        let mut descriptors = Vec::new();
+        let mut byte_offset = 4usize;
+        while byte_offset < length as usize {
+            let descriptor = BasicDataFormatDescriptor::from_bytes(&dfd_data[byte_offset..]);
+            // NOTE: Sanity check to not get stuck in an infinite loop
+            if descriptor.descriptor_block_size == 0 {
+                break;
+            }
+            byte_offset += descriptor.descriptor_block_size as usize;
+            descriptors.push(descriptor);
+        }
+        descriptors
     }
 }
 
@@ -118,10 +148,18 @@ pub struct Header {
     pub face_count: u32,
     pub level_count: u32,
     pub supercompression_scheme: Option<SupercompressionScheme>,
+    dfd_byte_offset: u32,
+    dfd_byte_length: u32,
+    kvd_byte_offset: u32,
+    kvd_byte_length: u32,
+    sgd_byte_offset: u64,
+    sgd_byte_length: u64,
 }
 
 impl Header {
-    fn from_bytes(data: &[u8; 48]) -> Self {
+    const LENGTH: usize = 80;
+
+    fn from_bytes(data: &[u8; Self::LENGTH]) -> Self {
         Self {
             format: Format::new(u32::from_le_bytes(data[12..16].try_into().unwrap())),
             type_size: u32::from_le_bytes(data[16..20].try_into().unwrap()),
@@ -132,6 +170,12 @@ impl Header {
             face_count: u32::from_le_bytes(data[36..40].try_into().unwrap()),
             level_count: u32::from_le_bytes(data[40..44].try_into().unwrap()),
             supercompression_scheme: SupercompressionScheme::new(u32::from_le_bytes(data[44..48].try_into().unwrap())),
+            dfd_byte_offset: u32::from_le_bytes(data[48..52].try_into().unwrap()),
+            dfd_byte_length: u32::from_le_bytes(data[52..56].try_into().unwrap()),
+            kvd_byte_offset: u32::from_le_bytes(data[56..60].try_into().unwrap()),
+            kvd_byte_length: u32::from_le_bytes(data[60..64].try_into().unwrap()),
+            sgd_byte_offset: u64::from_le_bytes(data[64..72].try_into().unwrap()),
+            sgd_byte_length: u64::from_le_bytes(data[72..80].try_into().unwrap()),
         }
     }
 
@@ -154,6 +198,8 @@ struct LevelIndex {
 }
 
 impl LevelIndex {
+    const LENGTH: usize = 24;
+
     pub fn from_bytes(data: &[u8]) -> Self {
         Self {
             offset: u64::from_le_bytes(data[0..8].try_into().unwrap()),
@@ -161,4 +207,366 @@ impl LevelIndex {
             uncompressed_length_bytes: u64::from_le_bytes(data[16..24].try_into().unwrap()),
         }
     }
+}
+
+bitflags::bitflags! {
+    #[repr(transparent)]
+    pub struct ChannelTypeQualifiers: u32 {
+        const LINEAR        = (1 << 0);
+        const EXPONENT      = (1 << 1);
+        const SIGNED        = (1 << 2);
+        const FLOAT         = (1 << 3);
+        const NONE          = 0;
+        const UNINITIALIZED = 0xFFFF;
+    }
+}
+
+bitflags::bitflags! {
+    #[derive(Default)]
+    #[repr(transparent)]
+    pub struct DataFormatFlags: u32 {
+        const ALPHA_PREMULTIPLIED        = (1 << 0);
+        const NONE          = 0;
+        const UNINITIALIZED = 0xFFFF;
+    }
+}
+
+// This can be obtained from std::mem::transmute::<f32, u32>(1.0f32) but we
+// want to support nostd. It is used for identifying normalized sample types
+// as in Unorm or Snorm
+const F32_1_AS_U32: u32 = 1065353216;
+
+#[derive(Debug, Default)]
+pub struct BasicDataFormatDescriptor {
+    pub vendor_id: u32,                      //: 17;
+    pub descriptor_type: u32,                //: 15;
+    pub version_number: u32,                 //: 16;
+    pub descriptor_block_size: u32,          //: 16;
+    pub color_model: ColorModel,             //: 8;
+    pub color_primaries: ColorPrimaries,     //: 8;
+    pub transfer_function: TransferFunction, //: 8;
+    pub flags: DataFormatFlags,              //: 8;
+    pub texel_block_dimensions: [u32; 4],    //: 8 x 4;
+    pub bytes_planes: [u32; 8],              //: 8 x 8;
+    pub samples: Vec<SampleInformation>,
+}
+
+impl BasicDataFormatDescriptor {
+    const HEADER_LENGTH: usize = 24;
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let mut offset = 0;
+
+        let v = bytes_to_u32(bytes, &mut offset);
+        let vendor_id = shift_and_mask_lower(0, 17, v);
+        assert_eq!(vendor_id, 0); // Basic Data Format Descriptor requirement
+        let descriptor_type = shift_and_mask_lower(17, 15, v);
+        assert_eq!(descriptor_type, 0); // Basic Data Format Descriptor requirement
+
+        let v = bytes_to_u32(bytes, &mut offset);
+        let version_number = shift_and_mask_lower(0, 16, v);
+        assert_eq!(version_number, 2); // Basic Data Format Descriptor requirement
+        let descriptor_block_size = shift_and_mask_lower(16, 16, v);
+
+        let n_samples = (descriptor_block_size - Self::HEADER_LENGTH as u32) / SampleInformation::LENGTH as u32;
+
+        let v = bytes_to_u32(bytes, &mut offset);
+        let model = shift_and_mask_lower(0, 8, v);
+        let primaries = shift_and_mask_lower(8, 8, v);
+        let transfer = shift_and_mask_lower(16, 8, v);
+        let flags = shift_and_mask_lower(24, 8, v);
+
+        let v = bytes_to_u32(bytes, &mut offset);
+        let texel_block_dimensions = [
+            shift_and_mask_lower(0, 8, v) + 1,
+            shift_and_mask_lower(8, 8, v) + 1,
+            shift_and_mask_lower(16, 8, v) + 1,
+            shift_and_mask_lower(24, 8, v) + 1,
+        ];
+
+        let v = bytes_to_u32(bytes, &mut offset);
+        let mut bytes_planes = [0u32; 8];
+        bytes_planes[0] = shift_and_mask_lower(0, 8, v);
+        bytes_planes[1] = shift_and_mask_lower(8, 8, v);
+        bytes_planes[2] = shift_and_mask_lower(16, 8, v);
+        bytes_planes[3] = shift_and_mask_lower(24, 8, v);
+
+        let v = bytes_to_u32(bytes, &mut offset);
+        bytes_planes[4] = shift_and_mask_lower(0, 8, v);
+        bytes_planes[5] = shift_and_mask_lower(8, 8, v);
+        bytes_planes[6] = shift_and_mask_lower(16, 8, v);
+        bytes_planes[7] = shift_and_mask_lower(24, 8, v);
+
+        let mut samples = Vec::new();
+        while (samples.len() as u32) < n_samples {
+            samples.push(SampleInformation::from_bytes(&bytes[offset..offset + 16]));
+            offset += 16;
+        }
+        assert_eq!(offset as u32, descriptor_block_size);
+
+        Self {
+            vendor_id,
+            descriptor_type,
+            version_number,
+            descriptor_block_size,
+            color_model: ColorModel::from(model),
+            color_primaries: ColorPrimaries::from(primaries),
+            transfer_function: TransferFunction::from(transfer),
+            flags: DataFormatFlags::from_bits_truncate(flags),
+            texel_block_dimensions,
+            bytes_planes,
+            samples,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SampleInformation {
+    pub bit_offset: u32,                                //: 16;
+    pub bit_length: u32,                                //: 8;
+    pub channel_type: u32,                              //: 4;
+    pub channel_type_qualifiers: ChannelTypeQualifiers, //: 4;
+    pub sample_positions: [u32; 4],                     //: 8 x 4;
+    pub lower: u32,                                     //;
+    pub upper: u32,                                     //;
+}
+
+impl SampleInformation {
+    const LENGTH: usize = 16;
+
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let mut offset = 0;
+
+        let v = bytes_to_u32(bytes, &mut offset);
+        let bit_offset = shift_and_mask_lower(0, 16, v);
+        let bit_length = shift_and_mask_lower(16, 8, v) + 1;
+        let channel_type = shift_and_mask_lower(24, 4, v);
+        let channel_type_qualifiers = ChannelTypeQualifiers::from_bits_truncate(shift_and_mask_lower(24, 4, v));
+
+        let v = bytes_to_u32(bytes, &mut offset);
+        let sample_positions = [
+            shift_and_mask_lower(0, 8, v),
+            shift_and_mask_lower(8, 8, v),
+            shift_and_mask_lower(16, 8, v),
+            shift_and_mask_lower(24, 8, v),
+        ];
+        let lower = bytes_to_u32(bytes, &mut offset);
+        let upper = bytes_to_u32(bytes, &mut offset);
+
+        assert_eq!(offset, 16);
+
+        Self {
+            bit_offset,
+            bit_length,
+            channel_type,
+            channel_type_qualifiers,
+            sample_positions,
+            lower,
+            upper,
+        }
+    }
+
+    pub fn is_exponent(&self) -> bool {
+        self.channel_type_qualifiers.contains(ChannelTypeQualifiers::EXPONENT)
+    }
+
+    pub fn is_float(&self) -> bool {
+        self.channel_type_qualifiers.contains(ChannelTypeQualifiers::FLOAT)
+    }
+
+    pub fn is_linear(&self) -> bool {
+        self.channel_type_qualifiers.contains(ChannelTypeQualifiers::LINEAR)
+    }
+
+    pub fn is_signed(&self) -> bool {
+        self.channel_type_qualifiers.contains(ChannelTypeQualifiers::SIGNED)
+    }
+
+    pub fn is_norm(&self) -> bool {
+        self.is_float() && self.upper == F32_1_AS_U32
+    }
+}
+
+#[derive(Debug)]
+pub enum ColorModel {
+    Unspecified = 0,
+    RGBSDA = 1,
+    YUVSDA = 2,
+    YIQSDA = 3,
+    LabSDA = 4,
+    CMYKA = 5,
+    XYZW = 6,
+    HSVAAng = 7,
+    HSLAAng = 8,
+    HSVAHex = 9,
+    HSLAHex = 10,
+    YCgCoA = 11,
+    YcCbcCrc = 12,
+    ICtCp = 13,
+    CIEXYZ = 14,
+    CIEXYY = 15,
+    BC1A = 128,
+    BC2 = 129,
+    BC3 = 130,
+    BC4 = 131,
+    BC5 = 132,
+    BC6H = 133,
+    BC7 = 134,
+    ETC1 = 160,
+    ETC2 = 161,
+    ASTC = 162,
+    ETC1S = 163,
+    PVRTC = 164,
+    PVRTC2 = 165,
+    UASTC = 166,
+}
+
+impl From<u32> for ColorModel {
+    fn from(color_model: u32) -> Self {
+        match color_model {
+            1 => Self::RGBSDA,
+            2 => Self::YUVSDA,
+            3 => Self::YIQSDA,
+            4 => Self::LabSDA,
+            5 => Self::CMYKA,
+            6 => Self::XYZW,
+            7 => Self::HSVAAng,
+            8 => Self::HSLAAng,
+            9 => Self::HSVAHex,
+            10 => Self::HSLAHex,
+            11 => Self::YCgCoA,
+            12 => Self::YcCbcCrc,
+            13 => Self::ICtCp,
+            14 => Self::CIEXYZ,
+            15 => Self::CIEXYY,
+            128 => Self::BC1A,
+            129 => Self::BC2,
+            130 => Self::BC3,
+            131 => Self::BC4,
+            132 => Self::BC5,
+            133 => Self::BC6H,
+            134 => Self::BC7,
+            160 => Self::ETC1,
+            161 => Self::ETC2,
+            162 => Self::ASTC,
+            163 => Self::ETC1S,
+            164 => Self::PVRTC,
+            165 => Self::PVRTC2,
+            166 => Self::UASTC,
+            0 | _ => Self::Unspecified,
+        }
+    }
+}
+
+impl Default for ColorModel {
+    fn default() -> Self {
+        Self::Unspecified
+    }
+}
+
+#[derive(Debug)]
+pub enum ColorPrimaries {
+    Unspecified = 0,
+    BT709 = 1,
+    BT601EBU = 2,
+    BT601SMPTE = 3,
+    BT2020 = 4,
+    CIEXYZ = 5,
+    ACES = 6,
+    ACESCC = 7,
+    NTSC1953 = 8,
+    PAL525 = 9,
+    DISPLAYP3 = 10,
+    AdobeRGB = 11,
+}
+
+impl Default for ColorPrimaries {
+    fn default() -> Self {
+        Self::Unspecified
+    }
+}
+
+impl From<u32> for ColorPrimaries {
+    fn from(color_primaries: u32) -> Self {
+        match color_primaries {
+            1 => Self::BT709,
+            2 => Self::BT601EBU,
+            3 => Self::BT601SMPTE,
+            4 => Self::BT2020,
+            5 => Self::CIEXYZ,
+            6 => Self::ACES,
+            7 => Self::ACESCC,
+            8 => Self::NTSC1953,
+            9 => Self::PAL525,
+            10 => Self::DISPLAYP3,
+            11 => Self::AdobeRGB,
+            0 | _ => Self::Unspecified,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum TransferFunction {
+    Unspecified = 0,
+    Linear = 1,
+    SRGB = 2,
+    ITU = 3,
+    NTSC = 4,
+    SLOG = 5,
+    SLOG2 = 6,
+    BT1886 = 7,
+    HLGOETF = 8,
+    HLGEOTF = 9,
+    PQEOTF = 10,
+    PQOETF = 11,
+    DCIP3 = 12,
+    PALOETF = 13,
+    PAL625EOTF = 14,
+    ST240 = 15,
+    ACESCC = 16,
+    ACESCCT = 17,
+    AdobeRGB = 18,
+}
+
+impl Default for TransferFunction {
+    fn default() -> Self {
+        Self::Unspecified
+    }
+}
+
+impl From<u32> for TransferFunction {
+    fn from(transfer_function: u32) -> Self {
+        match transfer_function {
+            1 => Self::Linear,
+            2 => Self::SRGB,
+            3 => Self::ITU,
+            4 => Self::NTSC,
+            5 => Self::SLOG,
+            6 => Self::SLOG2,
+            7 => Self::BT1886,
+            8 => Self::HLGOETF,
+            9 => Self::HLGEOTF,
+            10 => Self::PQEOTF,
+            11 => Self::PQOETF,
+            12 => Self::DCIP3,
+            13 => Self::PALOETF,
+            14 => Self::PAL625EOTF,
+            15 => Self::ST240,
+            16 => Self::ACESCC,
+            17 => Self::ACESCCT,
+            18 => Self::AdobeRGB,
+            0 | _ => Self::Unspecified,
+        }
+    }
+}
+
+#[inline]
+fn bytes_to_u32(bytes: &[u8], offset: &mut usize) -> u32 {
+    let v = u32::from_le_bytes(bytes[*offset..*offset + 4].try_into().unwrap());
+    *offset += 4;
+    v
+}
+
+#[inline]
+fn shift_and_mask_lower(shift: u32, mask: u32, value: u32) -> u32 {
+    (value >> shift) & ((1 << mask) - 1)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,13 +54,7 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         let header = Header::from_bytes(header_data);
         header.validate()?;
 
-        // Check data format descriptor integrity
-        let mut offset = header.dfd_byte_offset as usize;
-        let length = bytes_to_u32(input.as_ref(), &mut offset)?;
-        if length != header.dfd_byte_length
-            || length != header.kvd_byte_offset - header.dfd_byte_offset
-            || input.as_ref().len() < header.kvd_byte_offset as usize
-        {
+        if (header.dfd_byte_offset + header.dfd_byte_length) as usize >= input.as_ref().len() {
             return Err(ParseError::UnexpectedEnd);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -565,14 +565,12 @@ impl From<u32> for TransferFunction {
     }
 }
 
-#[inline]
 fn bytes_to_u32(bytes: &[u8], offset: &mut usize) -> u32 {
     let v = u32::from_le_bytes(bytes[*offset..*offset + 4].try_into().unwrap());
     *offset += 4;
     v
 }
 
-#[inline]
 fn shift_and_mask_lower(shift: u32, mask: u32, value: u32) -> u32 {
     (value >> shift) & ((1 << mask) - 1)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,8 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         let start = header.dfd_byte_offset as usize;
         let end = (header.dfd_byte_offset + header.dfd_byte_length) as usize;
         DataFormatDescriptorIterator {
-            data: &self.input.as_ref()[start..end],
+            // start + 4 to skip the data format descriptors total length
+            data: &self.input.as_ref()[start + 4..end],
             offset: 0,
         }
     }
@@ -253,7 +254,7 @@ bitflags::bitflags! {
     }
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct DataFormatDescriptorHeader {
     pub vendor_id: u32,       //: 17;
     pub descriptor_type: u32, //: 15;


### PR DESCRIPTION
## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] `cargo test` shows all tests passing
- [x] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description

Add support for parsing Data Format Descriptor sections from KTX2 files.