### PR TITLE
Add an iterator for key-value pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Per Keep a Changelog there are 6 main categories of changes:
 
 ## Unreleased
 
+Added a `key_value_data` function to the reader that returns an iterator over key-value pairs (by @expenses).
+
 ## v0.3.0
 
 Released 2022-02-03
@@ -34,4 +36,3 @@ Initial release under new ownership.
 ## Diffs
 
 - [Unreleased](https://github.com/BVE-Reborn/ktx2/compare/v0.3.0...HEAD)
-

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Parser for the [ktx2](https://github.khronos.org/KTX-Specification/) texture con
 - [x] Parsing
 - [x] Validating
 - [x] [Data format description](https://github.khronos.org/KTX-Specification/#_data_format_descriptor)
-- [ ] [Key/value data](https://github.khronos.org/KTX-Specification/#_keyvalue_data)
+- [x] [Key/value data](https://github.khronos.org/KTX-Specification/#_keyvalue_data)
 
 License: Apache-2.0
-

--- a/examples/load.rs
+++ b/examples/load.rs
@@ -7,6 +7,13 @@ fn main() {
     println!("Header: {:#?}", header);
     assert_head(header);
 
+    let key_value_pairs = reader.key_value_data().collect::<Vec<_>>();
+    assert_eq!(key_value_pairs.len(), 2);
+
+    for (k, v) in key_value_pairs {
+        println!("Key '{}': {}", String::from_utf8_lossy(k), String::from_utf8_lossy(v));
+    }
+
     let levels = reader.levels().collect::<Vec<_>>();
     assert_eq!(levels.len(), header.level_count.max(1) as usize);
 

--- a/examples/load.rs
+++ b/examples/load.rs
@@ -11,7 +11,7 @@ fn main() {
     assert_eq!(key_value_pairs.len(), 2);
 
     for (k, v) in key_value_pairs {
-        println!("Key '{}': {}", String::from_utf8_lossy(k), String::from_utf8_lossy(v));
+        println!("Key '{}': {}", k, String::from_utf8_lossy(v));
     }
 
     let levels = reader.levels().collect::<Vec<_>>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,13 +504,15 @@ fn test_malformed_key_value_data_handling() {
         b"abcdefghi!! ",
         // Regular key-value pair again
         &7_u32.to_le_bytes()[..],
-        b"xyz\0123",
+        b"abc\0987",
         &1000_u32.to_le_bytes()[..],
         &[1; 1000],
         &u32::MAX.to_le_bytes()[..],
     ];
 
-    let iterator = KeyValueDataIterator { data: &data.concat() };
+    let mut iterator = KeyValueDataIterator { data: &data.concat() };
 
-    assert_eq!(iterator.count(), 2);
+    assert_eq!(iterator.next(), Some(("xyz", &b"123"[..])));
+    assert_eq!(iterator.next(), Some(("abc", &b"987"[..])));
+    assert_eq!(iterator.next(), None);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,13 +177,12 @@ impl<'data> Iterator for KeyValueDataIterator<'data> {
             offset += 4 - (offset % 4);
         }
 
+        self.data = &self.data[offset..];
+
         // The key is terminated with a NUL character.
         let key_end_index = match key_and_value.iter().position(|&c| c == b'\0') {
             Some(key_and_value) => key_and_value,
-            None => {
-                self.data = &self.data[offset..];
-                return Some(("", &[]));
-            }
+            None => return Some(("", &[])),
         };
 
         let key = &key_and_value[..key_end_index];
@@ -191,13 +190,8 @@ impl<'data> Iterator for KeyValueDataIterator<'data> {
 
         let key = match std::str::from_utf8(key) {
             Ok(key) => key,
-            Err(_) => {
-                self.data = &self.data[offset..];
-                return Some(("", value));
-            }
+            Err(_) => return Some(("", value)),
         };
-
-        self.data = &self.data[offset..];
 
         Some((key, value))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,21 +171,23 @@ impl<'data> Iterator for KeyValueDataIterator<'data> {
 
             let start_offset = offset;
 
-            offset += length as usize;
+            offset = offset.checked_add(length as usize)?;
+
+            let end_offset = offset;
 
             // Ensure that we're 4-byte aligned
             if offset % 4 != 0 {
                 offset += 4 - (offset % 4);
             }
 
-            let key_and_value = match self.data.get(start_offset..start_offset + length as usize) {
+            let key_and_value = match self.data.get(start_offset..end_offset) {
                 Some(key_and_value) => key_and_value,
                 None => continue,
             };
 
             // The key is terminated with a NUL character.
             let key_end_index = match key_and_value.iter().position(|&c| c == b'\0') {
-                Some(key_and_value) => key_and_value,
+                Some(index) => index,
                 None => continue,
             };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,18 +164,14 @@ impl<'data> Iterator for KeyValueDataIterator<'data> {
     type Item = (&'data [u8], &'data [u8]);
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.data.len() < 4 {
-            return None;
-        }
-
         let mut offset = 0;
 
-        let length = bytes_to_u32(self.data, &mut offset).unwrap();
+        let length = bytes_to_u32(self.data, &mut offset).ok()?;
 
         let key_and_value = &self.data[offset..offset + length as usize];
 
         // The key is terminated with a NUL character.
-        let key_end_index = key_and_value.iter().position(|&c| c == b'\0').unwrap();
+        let key_end_index = key_and_value.iter().position(|&c| c == b'\0')?;
 
         let key = &key_and_value[..key_end_index];
         let value = &key_and_value[key_end_index + 1..];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,6 +495,7 @@ fn shift_and_mask_lower(shift: u32, mask: u32, value: u32) -> u32 {
 #[test]
 fn test_malformed_key_value_data_handling() {
     let data = [
+        &0_u32.to_le_bytes()[..],
         // Regular key-value pair
         &7_u32.to_le_bytes()[..],
         b"xyz\0123 ",
@@ -504,6 +505,9 @@ fn test_malformed_key_value_data_handling() {
         // Regular key-value pair again
         &7_u32.to_le_bytes()[..],
         b"xyz\0123",
+        &1000_u32.to_le_bytes()[..],
+        &[1; 1000],
+        &u32::MAX.to_le_bytes()[..],
     ];
 
     let iterator = KeyValueDataIterator { data: &data.concat() };


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate that your PR will pass CI -->

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] `cargo test` shows all tests passing
- [x] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description

I had already implemented key-value pair reading in my previous ktx2 project: https://github.com/expenses/kayteex so I thought I'd do the same here to tick off that feature in the readme.

## Related Issues
