### PR TITLE
Add `Header::as_bytes` and `LevelIndex::as_bytes`, move the index into it's own struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@ Per Keep a Changelog there are 6 main categories of changes:
 
 - Added a `key_value_data` function to the reader that returns an iterator over key-value pairs (by @expenses).
 - `Reader::levels` now returns an iterator over `Level` structs, which contain the bytes of the level as well as the uncompressed length (by @expenses).
-- Added `Header::from_bytes` and `LevelIndex::from_bytes` (by @expenses).
+- Added `Header::from_bytes`, `Header::as_bytes`, `LevelIndex::from_bytes` and `LevelIndex::as_bytes` (by @expenses).
 - Made the following fields public (by @expenses):
   - `Header::LENGTH`
+  - `Header::index`
   - `LevelIndex::LENGTH`
   - `LevelIndex::byte_offset`
   - `LevelIndex::byte_length`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,7 @@ pub struct Header {
     pub index: Index,
 }
 
+/// An index giving the byte offsets from the start of the file and byte sizes of the various sections of the KTX file.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct Index {
     pub dfd_byte_offset: u32,


### PR DESCRIPTION
## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] `cargo test` shows all tests passing
- [x] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description

Me again :) 

I started looking into writing ktx2 files as well as just reading them because I want to write various ktx2 compressors. This PR adds functions for converting the `Header` and `LevelIndex` back into byte arrays so that they can be passed to writers. Additionally, I made the `Index` it's own struct so that the fields in it could be made public without it polluting up the `Header`.

Used in:

https://github.com/expenses/ktx2-tools/blob/master/src/ktx2-compress.rs
