### PR TITLE
Make `KeyValueDataIterator` pub and add a ::new function to it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
     }
 
     /// Iterator over the key-value pairs
-    pub fn key_value_data(&self) -> impl Iterator<Item = (&str, &[u8])> + '_ {
+    pub fn key_value_data(&self) -> KeyValueDataIterator {
         let header = self.header();
 
         let start = header.index.kvd_byte_offset as usize;
@@ -208,7 +208,10 @@ pub struct KeyValueDataIterator<'data> {
 }
 
 impl<'data> KeyValueDataIterator<'data> {
-    /// Create a new iterator.
+    /// Create a new iterator from the key-value data section of the KTX2 file.
+    ///
+    /// From the start of the file, this is a slice between [`Index::kvd_byte_offset`]
+    /// and [`Index::kvd_byte_offset`] + [`Index::kvd_byte_length`].
     pub fn new(data: &'data [u8]) -> Self {
         Self { data }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         }
     }
 
+    /// Iterator over the key-value pairs
     pub fn key_value_data(&self) -> impl Iterator<Item = (&str, &[u8])> + '_ {
         let header = self.header();
 
@@ -172,9 +173,7 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         // Bounds-checking previously performed in `new`
         let end = (header.index.kvd_byte_offset + header.index.kvd_byte_length) as usize;
 
-        KeyValueDataIterator {
-            data: &self.input.as_ref()[start..end],
-        }
+        KeyValueDataIterator::new(&self.input.as_ref()[start..end])
     }
 }
 
@@ -203,8 +202,16 @@ impl<'data> Iterator for DataFormatDescriptorIterator<'data> {
     }
 }
 
-struct KeyValueDataIterator<'data> {
+/// An iterator that parses the key-value pairs in the KTX2 file.
+pub struct KeyValueDataIterator<'data> {
     data: &'data [u8],
+}
+
+impl<'data> KeyValueDataIterator<'data> {
+    /// Create a new iterator.
+    pub fn new(data: &'data [u8]) -> Self {
+        Self { data }
+    }
 }
 
 impl<'data> Iterator for KeyValueDataIterator<'data> {
@@ -280,7 +287,7 @@ pub struct Header {
     pub index: Index,
 }
 
-/// An index giving the byte offsets from the start of the file and byte sizes of the various sections of the KTX file.
+/// An index giving the byte offsets from the start of the file and byte sizes of the various sections of the KTX2 file.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct Index {
     pub dfd_byte_offset: u32,


### PR DESCRIPTION
I want to be able to pull out key-value pairs when I'm requesting individual chunks of the file separately. I've added this functionality as well as updated some documentation for consistency.

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] `cargo test` shows all tests passing
- [x] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description

## Related Issues
