### PR TITLE
Split BasicDataFormatDescriptorHeader off from BasicDataFormatDescriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Per Keep a Changelog there are 6 main categories of changes:
   - `LevelIndex::uncompressed_byte_length`
   - `Level::data`
   - `Level::uncompressed_byte_length`
+- Moved header data in `BasicDataFormatDescriptor` into `BasicDataFormatDescriptorHeader`.
 
 ## v0.3.0
 


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate that your PR will pass CI -->

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] `cargo test` shows all tests passing
- [x] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [ ] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description
This PR splits the header information from `BasicDataInformationDescriptor` into its own type to make way for encoding and decoding it separately.