### PR TITLE
Silence clippy warning about octal literals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,6 +602,7 @@ fn shift_and_mask_lower(shift: u32, mask: u32, value: u32) -> u32 {
 }
 
 #[test]
+#[allow(clippy::octal_escapes)]
 fn test_malformed_key_value_data_handling() {
     let data = [
         &0_u32.to_le_bytes()[..],


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate that your PR will pass CI -->

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] `cargo test` shows all tests passing
- [ ] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [ ] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description
Clippy warns about one of the literals in this test because it's worried about them looking like octal literals. This PR silences that PR in lieu of changing the test data.