### PR TITLE
Update to bitflags 2.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.4.2"
 
 [package.metadata.release]
 pre-release-hook = ["cargo", "readme", "-o", "README.md", "-t", "README.tpl"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,6 +401,7 @@ impl LevelIndex {
 }
 
 bitflags::bitflags! {
+    #[derive(Debug)]
     #[repr(transparent)]
     pub struct ChannelTypeQualifiers: u32 {
         const LINEAR        = (1 << 0);
@@ -411,7 +412,7 @@ bitflags::bitflags! {
 }
 
 bitflags::bitflags! {
-    #[derive(Default)]
+    #[derive(Clone, Copy, Debug, Default)]
     #[repr(transparent)]
     pub struct DataFormatFlags: u32 {
         const STRAIGHT_ALPHA             = 0;


### PR DESCRIPTION
## Checklist

- [ ] `cargo clippy` reports no issues
- [ ] `cargo doc` reports no issues
- [ ] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [ ] `cargo test` shows all tests passing
- [ ] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [ ] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description
Update to the latest version of the only dependency this crate has.

Might be a good idea to enable Dependabot this repo.