### PR TITLE
 Add MSRV and Misc Updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,14 @@
 [workspace]
-members = [
-]
+members = []
 
 [package]
 name = "ktx2"
 version = "0.3.0"
-authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>", "Connor Fitzgerald <connorwadefitzgerald@gmail.com>", "f3kilo <f3kilo@yandex.ru>"]
+authors = [
+    "Benjamin Saunders <ben.e.saunders@gmail.com>",
+    "Connor Fitzgerald <connorwadefitzgerald@gmail.com>",
+    "f3kilo <f3kilo@yandex.ru>",
+]
 edition = "2021"
 description = "Parser for the ktx2 texture container format"
 readme = "README.md"
@@ -13,10 +16,7 @@ repository = "https://github.com/BVE-Reborn/ktx2"
 license = "Apache-2.0"
 keywords = []
 categories = []
-exclude = [
-    "data/*",
-    
-]
+exclude = ["data/*"]
 
 [features]
 default = ["std"]
@@ -43,9 +43,11 @@ replace = "## Unreleased\n\n## v{{version}}\n\nReleased {{date}}"
 file = "CHANGELOG.md"
 search = "\\[Unreleased\\]\\(https://github.com/BVE-Reborn/ktx2/compare/v([a-z0-9.-]+)\\.\\.\\.HEAD\\)"
 replace = "[Unreleased](https://github.com/BVE-Reborn/ktx2/compare/v{{version}}...HEAD)\n- [v{{version}}](https://github.com/BVE-Reborn/ktx2/compare/v$1...v{{version}})"
-min = 0  # allow first increment
+# allow first increment
+min = 0
 [[package.metadata.release.pre-release-replacements]]
 file = "CHANGELOG.md"
 search = "<!-- Begin Diffs -->"
 replace = "- [Unreleased](https://github.com/BVE-Reborn/ktx2/compare/v{{version}}...HEAD)"
-min = 0  # allow non-first increment
+# allow non-first increment
+min = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ license = "Apache-2.0"
 keywords = []
 categories = []
 exclude = ["data/*"]
+rust-version = "1.56"
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # ktx2
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/BVE-Reborn/ktx2/Build)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/BVE-Reborn/ktx2/build.yml?branch=trunk)
 [![Crates.io](https://img.shields.io/crates/v/ktx2)](https://crates.io/crates/ktx2)
 [![Documentation](https://docs.rs/ktx2/badge.svg)](https://docs.rs/ktx2)
 ![License](https://img.shields.io/crates/l/ktx2)
-
 
 Parser for the [ktx2](https://github.khronos.org/KTX-Specification/ktxspec.v2.html) texture container format.
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,25 @@
 ![License](https://img.shields.io/crates/l/ktx2)
 
 
-Parser for the [ktx2](https://github.khronos.org/KTX-Specification/) texture container format.
+Parser for the [ktx2](https://github.khronos.org/KTX-Specification/ktxspec.v2.html) texture container format.
 
 ### Features
 - [x] Async reading
 - [x] Parsing
 - [x] Validating
-- [x] [Data format description](https://github.khronos.org/KTX-Specification/#_data_format_descriptor)
-- [x] [Key/value data](https://github.khronos.org/KTX-Specification/#_keyvalue_data)
+- [x] [Data format description](https://github.khronos.org/KTX-Specification/ktxspec.v2.html#_data_format_descriptor)
+- [x] [Key/value data](https://github.khronos.org/KTX-Specification/ktxspec.v2.html#_keyvalue_data)
+
+### Example
+```rust
+// Crate instance of reader. This validates the header
+let mut reader = ktx2::Reader::new(file).expect("Can't create reader"); // Crate instance of reader.
+
+// Get general texture information.
+let header = reader.header();
+
+// Read iterator over slices of each mipmap level.
+let levels = reader.levels().collect::<Vec<_>>();
+```
 
 License: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -27,4 +27,8 @@ let header = reader.header();
 let levels = reader.levels().collect::<Vec<_>>();
 ```
 
+### MSRV
+
+The minimum supported Rust version is 1.56. MSRV bumps are treated as breaking changes.
+
 License: Apache-2.0

--- a/README.tpl
+++ b/README.tpl
@@ -1,12 +1,10 @@
 # ktx2
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/BVE-Reborn/ktx2/Build)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/BVE-Reborn/ktx2/build.yml?branch=trunk)
 [![Crates.io](https://img.shields.io/crates/v/ktx2)](https://crates.io/crates/ktx2)
 [![Documentation](https://docs.rs/ktx2/badge.svg)](https://docs.rs/ktx2)
 ![License](https://img.shields.io/crates/l/ktx2)
 
-
 {{readme}}
 
 License: {{license}}
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,10 @@
 //! let levels = reader.levels().collect::<Vec<_>>();
 //! # let _ = (header, levels);
 //! ```
+//!
+//! ## MSRV
+//!
+//! The minimum supported Rust version is 1.56. MSRV bumps are treated as breaking changes.
 
 #![no_std]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@
 //! - [x] Parsing
 //! - [x] Validating
 //! - [x] [Data format description](https://github.khronos.org/KTX-Specification/ktxspec.v2.html#_data_format_descriptor)
-//! - [ ] [Key/value data](https://github.khronos.org/KTX-Specification/ktxspec.v2.html#_keyvalue_data)
-//
+//! - [x] [Key/value data](https://github.khronos.org/KTX-Specification/ktxspec.v2.html#_keyvalue_data)
+//!
 //! ## Example
 //! ```rust
 //! // Crate instance of reader. This validates the header


### PR DESCRIPTION
Adds an `MSRV` calculated using `cargo-msrv`. The CI added in #27 will also test to make sure MSRV works.

Review should be commit-by-commit.