### PR TITLE
Refactor dfd handling and add documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ Per Keep a Changelog there are 6 main categories of changes:
 
 ## Unreleased
 
+- Moved all Data Format Descriptor (DFD) types into new submodule called `dfd` and renamed them to be more
+  understandable.
+  - `DfdBlock` -> `dfd::Block`
+  - `DfdHeader` -> `dfd::BlockHeader`
+  - `DfdBlockBasic` -> `dfd::Basic`
+  - `DfdBlockHeaderBasic` -> `dfd::BasicHeader`
+  The following types moved into the `dfd` module unchanged.
+  - `ChannelTypeQualifiers`
+  - `ColorModel`
+  - `ColorPrimaries`
+  - `DataFormatFlags`
+  - `SampleInformation`
+  - `TransferFunction`
+
 ## v0.4.0
 
 Released 2025-03-24

--- a/src/dfd.rs
+++ b/src/dfd.rs
@@ -1,0 +1,302 @@
+//! Data Format Descriptor (DFD) for KTX2 textures.
+//!
+//! Each ktx2 file contains an abstract definition of the data format of the texture data,
+//! called the [Data Format Descriptor (DFD)][dfd-spec]). The specification for the DFD is a separate
+//! Khronos standard, and is not specific to KTX2.
+//!
+//! Most of the DFD's data is relatively esoteric, but it is required by the KTX2 specification,
+//! and contains information like [`ColorModel`], [`ColorPrimaries`], and [`TransferFunction`] that
+//! may be useful to applications.
+//!
+//! [dfd-spec]: https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.inline.html
+
+use core::num::NonZeroU8;
+
+pub use crate::enums::{ColorModel, ColorPrimaries, TransferFunction};
+use crate::{bytes_to_u32, read_bytes, read_u16, shift_and_mask_lower, ParseError};
+
+pub struct Block<'data> {
+    pub header: BlockHeader,
+    pub data: &'data [u8],
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct BlockHeader {
+    pub vendor_id: u32,       //: 17;
+    pub descriptor_type: u32, //: 15;
+    pub version_number: u16,  //: 16;
+}
+
+impl BlockHeader {
+    pub const LENGTH: usize = 8;
+
+    pub const BASIC: Self = Self {
+        vendor_id: 0,
+        descriptor_type: 0,
+        version_number: 2,
+    };
+
+    pub fn as_bytes(&self, descriptor_block_size: u16) -> [u8; Self::LENGTH] {
+        let mut output = [0u8; Self::LENGTH];
+
+        let first_word = (self.vendor_id & ((1 << 17) - 1)) | (self.descriptor_type << 17);
+        output[0..4].copy_from_slice(&first_word.to_le_bytes());
+        output[4..6].copy_from_slice(&self.version_number.to_le_bytes());
+        output[6..8].copy_from_slice(&descriptor_block_size.to_le_bytes());
+
+        output
+    }
+
+    pub(crate) fn parse(bytes: &[u8]) -> Result<(Self, usize), ParseError> {
+        let mut offset = 0;
+
+        let v = bytes_to_u32(bytes, &mut offset)?;
+        let vendor_id = shift_and_mask_lower(0, 17, v);
+        let descriptor_type = shift_and_mask_lower(17, 15, v);
+
+        let version_number = read_u16(bytes, &mut offset)?;
+        let descriptor_block_size = read_u16(bytes, &mut offset)?;
+
+        Ok((
+            Self {
+                vendor_id,
+                descriptor_type,
+                version_number,
+            },
+            descriptor_block_size as usize,
+        ))
+    }
+}
+
+pub struct Basic<'data> {
+    pub header: BasicHeader,
+    sample_information: &'data [u8],
+}
+
+impl<'data> Basic<'data> {
+    pub fn parse(bytes: &'data [u8]) -> Result<Self, ParseError> {
+        let header_data = bytes
+            .get(0..BasicHeader::LENGTH)
+            .ok_or(ParseError::UnexpectedEnd)?
+            .try_into()
+            .unwrap();
+        let header = BasicHeader::from_bytes(header_data)?;
+
+        Ok(Self {
+            header,
+            sample_information: &bytes[BasicHeader::LENGTH..],
+        })
+    }
+
+    pub fn sample_information(&self) -> impl Iterator<Item = SampleInformation> + 'data {
+        SampleInformationIterator {
+            data: self.sample_information,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct BasicHeader {
+    /// None means Unspecified
+    pub color_model: Option<ColorModel>, //: 8;
+    /// None means Unspecified
+    pub color_primaries: Option<ColorPrimaries>, //: 8;
+    /// None means Unspecified
+    pub transfer_function: Option<TransferFunction>, //: 8;
+    pub flags: DataFormatFlags,                 //: 8;
+    pub texel_block_dimensions: [NonZeroU8; 4], //: 8 x 4;
+    pub bytes_planes: [u8; 8],                  //: 8 x 8;
+}
+
+impl BasicHeader {
+    pub const LENGTH: usize = 16;
+
+    pub fn as_bytes(&self) -> [u8; Self::LENGTH] {
+        let mut bytes = [0u8; Self::LENGTH];
+
+        let color_model = self.color_model.map(|c| c.value()).unwrap_or(0);
+        let color_primaries = self.color_primaries.map(|c| c.value()).unwrap_or(0);
+        let transfer_function = self.transfer_function.map(|t| t.value()).unwrap_or(0);
+
+        let texel_block_dimensions = self.texel_block_dimensions.map(|dim| dim.get() - 1);
+
+        bytes[0] = color_model;
+        bytes[1] = color_primaries;
+        bytes[2] = transfer_function;
+        bytes[3] = self.flags.bits();
+        bytes[4..8].copy_from_slice(&texel_block_dimensions);
+        bytes[8..16].copy_from_slice(&self.bytes_planes);
+
+        bytes
+    }
+
+    pub fn from_bytes(bytes: &[u8; Self::LENGTH]) -> Result<Self, ParseError> {
+        let mut offset = 0;
+
+        let [model, primaries, transfer, flags] = read_bytes(bytes, &mut offset)?;
+        let texel_block_dimensions = read_bytes(bytes, &mut offset)?.map(|dim| NonZeroU8::new(dim + 1).unwrap());
+        let bytes_planes = read_bytes(bytes, &mut offset)?;
+
+        Ok(Self {
+            color_model: ColorModel::new(model),
+            color_primaries: ColorPrimaries::new(primaries),
+            transfer_function: TransferFunction::new(transfer),
+            flags: DataFormatFlags::from_bits_truncate(flags),
+            texel_block_dimensions,
+            bytes_planes,
+        })
+    }
+}
+
+struct SampleInformationIterator<'data> {
+    data: &'data [u8],
+}
+
+impl Iterator for SampleInformationIterator<'_> {
+    type Item = SampleInformation;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let bytes = self.data.get(0..SampleInformation::LENGTH)?.try_into().unwrap();
+        SampleInformation::from_bytes(&bytes).map_or(None, |sample_information| {
+            self.data = &self.data[SampleInformation::LENGTH..];
+            Some(sample_information)
+        })
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct SampleInformation {
+    pub bit_offset: u16,                                //: 16;
+    pub bit_length: NonZeroU8,                          //: 8;
+    pub channel_type: u8,                               //: 4;
+    pub channel_type_qualifiers: ChannelTypeQualifiers, //: 4;
+    pub sample_positions: [u8; 4],                      //: 8 x 4;
+    pub lower: u32,                                     //: 32;
+    pub upper: u32,                                     //: 32;
+}
+
+impl SampleInformation {
+    pub const LENGTH: usize = 16;
+
+    pub fn as_bytes(&self) -> [u8; Self::LENGTH] {
+        let mut bytes = [0u8; Self::LENGTH];
+
+        let channel_info = self.channel_type | (self.channel_type_qualifiers.bits() << 4);
+
+        bytes[0..2].copy_from_slice(&self.bit_offset.to_le_bytes());
+        bytes[2] = self.bit_length.get() - 1;
+        bytes[3] = channel_info;
+        bytes[4..8].copy_from_slice(&self.sample_positions);
+        bytes[8..12].copy_from_slice(&self.lower.to_le_bytes());
+        bytes[12..16].copy_from_slice(&self.upper.to_le_bytes());
+
+        bytes
+    }
+
+    pub fn from_bytes(bytes: &[u8; Self::LENGTH]) -> Result<Self, ParseError> {
+        let mut offset = 0;
+
+        let v = bytes_to_u32(bytes, &mut offset)?;
+        let bit_offset = shift_and_mask_lower(0, 16, v) as u16;
+        let bit_length = (shift_and_mask_lower(16, 8, v) as u8)
+            .checked_add(1)
+            .and_then(NonZeroU8::new)
+            .ok_or(ParseError::InvalidSampleBitLength)?;
+        let channel_type = shift_and_mask_lower(24, 4, v) as u8;
+        let channel_type_qualifiers = ChannelTypeQualifiers::from_bits_truncate(shift_and_mask_lower(28, 4, v) as u8);
+
+        let sample_positions = read_bytes(bytes, &mut offset)?;
+        let lower = bytes_to_u32(bytes, &mut offset)?;
+        let upper = bytes_to_u32(bytes, &mut offset)?;
+
+        Ok(Self {
+            bit_offset,
+            bit_length,
+            channel_type,
+            channel_type_qualifiers,
+            sample_positions,
+            lower,
+            upper,
+        })
+    }
+}
+
+bitflags::bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[repr(transparent)]
+    pub struct ChannelTypeQualifiers: u8 {
+        const LINEAR        = (1 << 0);
+        const EXPONENT      = (1 << 1);
+        const SIGNED        = (1 << 2);
+        const FLOAT         = (1 << 3);
+    }
+}
+
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    #[repr(transparent)]
+    pub struct DataFormatFlags: u8 {
+        const STRAIGHT_ALPHA             = 0;
+        const ALPHA_PREMULTIPLIED        = (1 << 0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn to_nonzero<const N: usize>(input: [u8; N]) -> [NonZeroU8; N] {
+        input.map(|n| NonZeroU8::new(n).unwrap())
+    }
+
+    #[test]
+    fn basic_dfd_header_roundtrip() {
+        let header = BasicHeader {
+            color_model: Some(ColorModel::LabSDA),
+            color_primaries: Some(ColorPrimaries::ACES),
+            transfer_function: Some(TransferFunction::ITU),
+            flags: DataFormatFlags::STRAIGHT_ALPHA,
+            texel_block_dimensions: to_nonzero([1, 2, 3, 4]),
+            bytes_planes: [5, 6, 7, 8, 9, 10, 11, 12],
+        };
+
+        let bytes = header.as_bytes();
+        let decoded = BasicHeader::from_bytes(&bytes).unwrap();
+        assert_eq!(header, decoded);
+    }
+
+    #[test]
+    fn sample_information_roundtrip() {
+        let info = SampleInformation {
+            bit_offset: 234,
+            bit_length: NonZeroU8::new(123).unwrap(),
+            channel_type: 2,
+            channel_type_qualifiers: ChannelTypeQualifiers::LINEAR,
+            sample_positions: [1, 2, 3, 4],
+            lower: 1234,
+            upper: 4567,
+        };
+
+        let bytes = info.as_bytes();
+        let decoded = SampleInformation::from_bytes(&bytes).unwrap();
+
+        assert_eq!(info, decoded);
+    }
+
+    #[test]
+    fn sample_info_invalid_bit_length() {
+        let bytes = &[
+            0u8, 0,   // bit_offset
+            255, // bit_length
+            1,   // channel_type | channel_type_qualifiers
+            0, 0, 0, 0, // sample_positions
+            0, 0, 0, 0, // lower
+            255, 255, 255, 255, // upper
+        ];
+
+        assert!(matches!(
+            SampleInformation::from_bytes(bytes),
+            Err(ParseError::InvalidSampleBitLength)
+        ));
+    }
+}

--- a/src/dfd.rs
+++ b/src/dfd.rs
@@ -8,6 +8,15 @@
 //! and contains information like [`ColorModel`], [`ColorPrimaries`], and [`TransferFunction`] that
 //! may be useful to applications.
 //!
+//! # Structure
+//!
+//! A DFD contains one or more [`Block`]s. Each block has a [`BlockHeader`], which describes what type of block it is,
+//! and a data blob. The most common block type in KTX2 is the [`Basic`] block which contains information about
+//! texture-like data formats.
+//!
+//! This [`Basic`] block itself has a fixed size [`BasicHeader`] followed by a variable-length array of [`SampleInformation`]
+//! entries.
+//!
 //! [dfd-spec]: https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.inline.html
 
 use core::num::NonZeroU8;
@@ -16,27 +25,41 @@ pub use crate::enums::{ColorModel, ColorPrimaries, TransferFunction};
 use crate::util::{bytes_to_u32, read_bytes, read_u16, shift_and_mask_lower};
 use crate::ParseError;
 
+/// DFD block, containing a header and a data blob.
+///
+/// The header describes the type of block, and the data blob contains the block's contents.
 pub struct Block<'data> {
     pub header: BlockHeader,
     pub data: &'data [u8],
 }
 
+/// DFD block header, containing what type and version of block.
+///
+/// Implementations can skip blocks with unrecognized headers, allowing unknown data to be ignored.
 #[derive(Debug, PartialEq, Eq)]
 pub struct BlockHeader {
-    pub vendor_id: u32,       //: 17;
+    /// 17-bit organization identifier. `0` is Khronos. PCI SIG IDs use bits 0–15 with bit 16
+    /// clear; other IDs are assigned by Khronos starting at 65536.
+    pub vendor_id: u32, //: 17;
+    /// 15-bit vendor-defined identifier distinguishing between data representations.
     pub descriptor_type: u32, //: 15;
-    pub version_number: u16,  //: 16;
+    /// Vendor-defined version, intended for backwards-compatible updates to a descriptor block.
+    pub version_number: u16, //: 16;
 }
 
 impl BlockHeader {
+    /// Number of bytes in a DFD block header.
     pub const LENGTH: usize = 8;
 
+    /// The header for a [`Basic`] block.
     pub const BASIC: Self = Self {
         vendor_id: 0,
         descriptor_type: 0,
         version_number: 2,
     };
 
+    /// Serializes the block header to bytes, using the provided `descriptor_block_size` for the
+    /// size of the [`Block::data`] field.
     pub fn as_bytes(&self, descriptor_block_size: u16) -> [u8; Self::LENGTH] {
         let mut output = [0u8; Self::LENGTH];
 
@@ -48,6 +71,8 @@ impl BlockHeader {
         output
     }
 
+    /// Parses a block header from the start of `bytes`, returning the header and the size
+    /// of the following [`Block::data`] field.
     pub(crate) fn parse(bytes: &[u8]) -> Result<(Self, usize), ParseError> {
         let mut offset = 0;
 
@@ -69,12 +94,16 @@ impl BlockHeader {
     }
 }
 
+/// "Basic" DFD block, containing information about texture-like data.
+///
+/// This is the most common type of DFD block found in KTX2 files.
 pub struct Basic<'data> {
     pub header: BasicHeader,
     sample_information: &'data [u8],
 }
 
 impl<'data> Basic<'data> {
+    /// Parses a [`Basic`] block from the start of `bytes`.
     pub fn parse(bytes: &'data [u8]) -> Result<Self, ParseError> {
         let header_data = bytes
             .get(0..BasicHeader::LENGTH)
@@ -89,6 +118,7 @@ impl<'data> Basic<'data> {
         })
     }
 
+    /// Iterator over the [`SampleInformation`] entries in this block.
     pub fn sample_information(&self) -> impl Iterator<Item = SampleInformation> + 'data {
         SampleInformationIterator {
             data: self.sample_information,
@@ -96,22 +126,62 @@ impl<'data> Basic<'data> {
     }
 }
 
+/// Constant size data for a [`Basic`] DFD block.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BasicHeader {
-    /// None means Unspecified
+    /// The set of color (or other data) channels which may be encoded within the data,
+    /// though there is no requirement that all of the possible channels from the colorModel
+    /// be present.
+    ///
+    /// See the [DFD specification][dfd-spec] for more information on this than you'd ever need.
+    ///
+    /// None means unknown/unspecified.
+    ///
+    /// [dfd-spec]: https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.inline.html#COLORMODEL
     pub color_model: Option<ColorModel>, //: 8;
-    /// None means Unspecified
+    /// The color primaries used by the data.
+    ///
+    /// See the [DFD specification][dfd-spec] for more information than you can shake a stick at.
+    ///
+    /// None means unknown/unspecified.
+    ///
+    /// [dfd-spec]: https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.inline.html#_emphasis_role_strong_emphasis_colorprimaries_emphasis_emphasis
     pub color_primaries: Option<ColorPrimaries>, //: 8;
-    /// None means Unspecified
+    /// The function converting the encoded data to a linear color space.
+    ///
+    /// See the [DFD specification][dfd-spec] for more information.
+    ///
+    /// None means unknown/unspecified.
+    ///
+    /// [dfd-spec]: https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.inline.html#_emphasis_role_strong_emphasis_transferfunction_emphasis_emphasis
     pub transfer_function: Option<TransferFunction>, //: 8;
-    pub flags: DataFormatFlags,                 //: 8;
+    /// Boolean flags modifying properties of the data. In practice,
+    /// this is only used to indicate if the alpha channel is premultiplied.
+    ///
+    /// See the [DFD specification][dfd-spec] for more information.
+    ///
+    /// [dfd-spec]: https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.inline.html#_emphasis_role_strong_emphasis_flags_emphasis_emphasis
+    pub flags: DataFormatFlags, //: 8;
+    /// The dimensions of each "block" of texels in the image. For uncompressed formats, this is always 1x1x1x1.
+    /// For compressed formats, this represents the dimensions of the compression block (e.g. 4x4x1x1 for BCn formats).
+    ///
+    /// The dfd stores this as one less than the actual dimension. See the [DFD specification][dfd-spec] for more information.
+    ///
+    /// [dfd-spec]: https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.inline.html#_emphasis_role_strong_emphasis_texelblockdimension_0_3_emphasis_emphasis
     pub texel_block_dimensions: [NonZeroU8; 4], //: 8 x 4;
-    pub bytes_planes: [u8; 8],                  //: 8 x 8;
+    /// The number of bytes in each plane of the data.
+    ///
+    /// See the [DFD specification][dfd-spec] for more information.
+    ///
+    /// [dfd-spec]: https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.inline.html#_emphasis_role_strong_emphasis_bytesplane_0_7_emphasis_emphasis
+    pub bytes_planes: [u8; 8], //: 8 x 8;
 }
 
 impl BasicHeader {
+    /// Number of bytes in a BasicHeader.
     pub const LENGTH: usize = 16;
 
+    /// Serializes the block header to bytes.
     pub fn as_bytes(&self) -> [u8; Self::LENGTH] {
         let mut bytes = [0u8; Self::LENGTH];
 
@@ -131,6 +201,7 @@ impl BasicHeader {
         bytes
     }
 
+    /// Deserializes a block header from the given bytes.
     pub fn from_bytes(bytes: &[u8; Self::LENGTH]) -> Result<Self, ParseError> {
         let mut offset = 0;
 
@@ -165,20 +236,70 @@ impl Iterator for SampleInformationIterator<'_> {
     }
 }
 
+/// Information about each "sample" within an image.
+///
+/// A "sample" consisting of a single channel of data and with a
+/// single corresponding "position" within the texel block.
+///
+/// See the [DFD specification][dfd-spec] for more extremely verbose information.
+///
+/// [dfd-spec]: https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.inline.html#_anchor_id_sample_xreflabel_sample_sample_information
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct SampleInformation {
-    pub bit_offset: u16,                                //: 16;
-    pub bit_length: NonZeroU8,                          //: 8;
-    pub channel_type: u8,                               //: 4;
+    /// Offset from the beginning of the texel block in bits.
+    pub bit_offset: u16, //: 16;
+    /// The length of this sample in bits.
+    pub bit_length: NonZeroU8, //: 8;
+    /// The type of channel this sample represents. This varies by [`ColorModel`].
+    pub channel_type: u8, //: 4;
+    /// Qualifiers modifying the channel type.
     pub channel_type_qualifiers: ChannelTypeQualifiers, //: 4;
-    pub sample_positions: [u8; 4],                      //: 8 x 4;
-    pub lower: u32,                                     //: 32;
-    pub upper: u32,                                     //: 32;
+    /// The position in texels of this sample relative to the 0,0,0,0 texel in the 4D texel block.
+    pub sample_positions: [u8; 4], //: 8 x 4;
+    /// The sample value that maps to the format's logical minimum — typically `0` for unsigned
+    /// formats, `-1` for signed formats, or `-0.5` for chroma channels in color difference models
+    /// (e.g. Y′CbCr).
+    ///
+    /// Together with [`upper`](Self::upper), this defines how raw sample values are converted to
+    /// their conceptual numeric interpretation. Values are not guaranteed to fall within this
+    /// range — for example, HDR formats may define `1.0` as a nominal level well below the actual
+    /// maximum. When samples should be interpreted directly as integers (unnormalized), set
+    /// [`upper`](Self::upper) to `1` and `lower` to `0` (unsigned) or `-1` (signed).
+    ///
+    /// For integer formats, this is stored as a 32-bit integer (signed or unsigned matching the
+    /// channel encoding). For floating-point formats, it is stored as a 32-bit float. For formats
+    /// wider than 32 bits (e.g. 64-bit), integer values are expanded by preserving the sign bit
+    /// and replicating the top non-sign bit, and float values are converted to the native
+    /// representation (e.g. `f32` to `f64`).
+    ///
+    /// # Examples
+    ///
+    /// | Format | `lower` | `upper` | Effect |
+    /// |--------|---------|---------|--------|
+    /// | R8 unorm | `0` | `255` | Maps 0–255 to 0.0–1.0 |
+    /// | R8 snorm | `-127` (`0xFFFFFF81`) | `127` | Maps -127–127 to -1.0–1.0 |
+    /// | R8 uint | `0` | `1` | Integer value used directly |
+    /// | R16 sfloat | `0xBF800000` (-1.0f) | `0x3F800000` (1.0f) | Float range -1.0–1.0 |
+    /// | R64 uint | `0` | `1` | Expands to 64-bit `0` and `1` |
+    /// | R64 uint norm | `0` | `0xFFFFFFFF` | Expands to `u64::MAX`, maps to 0.0–1.0 |
+    /// | BT.709 Y′ (8-bit) | `16` | `235` | Maps 16–235 to 0.0–1.0 |
+    ///
+    /// For a very long and confusing explanation of this, please see the [DFD specification][dfd-spec]
+    ///
+    /// [dfd-spec]: https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.inline.html#_emphasis_role_strong_emphasis_samplelower_emphasis_emphasis_and_emphasis_role_strong_emphasis_sampleupper_emphasis_emphasis
+    pub lower: u32, //: 32;
+    /// The sample value that maps to `1.0` (the white point), or `0.5` for chroma channels in
+    /// color difference models (e.g. Y′CbCr).
+    ///
+    /// See [`lower`](Self::lower) for more details on interpretation and encoding and examples.
+    pub upper: u32, //: 32;
 }
 
 impl SampleInformation {
+    /// Number of bytes in a SampleInformation entry.
     pub const LENGTH: usize = 16;
 
+    /// Serializes this sample information to bytes.
     pub fn as_bytes(&self) -> [u8; Self::LENGTH] {
         let mut bytes = [0u8; Self::LENGTH];
 
@@ -194,6 +315,7 @@ impl SampleInformation {
         bytes
     }
 
+    /// Deserializes sample information from the given bytes.
     pub fn from_bytes(bytes: &[u8; Self::LENGTH]) -> Result<Self, ParseError> {
         let mut offset = 0;
 
@@ -223,21 +345,61 @@ impl SampleInformation {
 }
 
 bitflags::bitflags! {
+    /// Qualifiers modifying the channel type of a [`SampleInformation`] entry.
+    ///
+    /// Multiple samples with the same channel and position are combined into a single logical
+    /// ("virtual") sample. Samples without [`EXPONENT`](Self::EXPONENT) set contribute to the
+    /// **base value** — the primary numeric content of the channel (e.g. a color intensity or
+    /// mantissa). Samples with [`EXPONENT`](Self::EXPONENT) set act as **modifiers** that
+    /// transform the base value — the interpretation depends on the combination of flags:
+    ///
+    /// | `EXPONENT` | `LINEAR` | `FLOAT` | Interpretation |
+    /// |:----------:|:--------:|:-------:|----------------|
+    /// | - | - | - | Base value, modified by [`TransferFunction`] |
+    /// | - | L | - | Base value, always linear (ignores [`TransferFunction`]) |
+    /// | - | - | F | Base value is a standard float (10/11/16/32/64-bit) |
+    /// | E | - | - | Exponent: `base × 2^modifier` |
+    /// | E | - | F | Multiplier: `base × modifier` |
+    /// | E | L | - | Divisor: `base / modifier` |
+    /// | E | L | F | Power: `base ^ modifier` |
+    ///
+    /// For a long and more confusing explanation of this, see the [DFD specification][dfd-spec].
+    ///
+    /// [dfd-spec]: https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.inline.html#_sample_emphasis_role_strong_emphasis_channeltype_emphasis_emphasis_emphasis_role_strong_emphasis_channelid_emphasis_emphasis_and_qualifiers
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[repr(transparent)]
     pub struct ChannelTypeQualifiers: u8 {
+        /// The sample contains a linearly-encoded value, bypassing the format's
+        /// [`TransferFunction`]. When combined with [`EXPONENT`](Self::EXPONENT), indicates a
+        /// divisor modifier instead.
         const LINEAR        = (1 << 0);
+        /// The sample is a modifier applied to the base value rather than part of the base value
+        /// itself. The type of modification depends on the [`LINEAR`](Self::LINEAR) and
+        /// [`FLOAT`](Self::FLOAT) flags — see the table on [`ChannelTypeQualifiers`].
         const EXPONENT      = (1 << 1);
+        /// The sample holds a signed two's complement value. When not set, the sample is unsigned.
         const SIGNED        = (1 << 2);
+        /// The sample holds floating-point data (10/11/16/32/64-bit IEEE 754). For custom float
+        /// formats with a separate [`EXPONENT`](Self::EXPONENT) sample, this flag on the base
+        /// value instead indicates an implicit leading `1` bit in the mantissa.
+        /// When combined with [`EXPONENT`](Self::EXPONENT), indicates a multiplier modifier.
         const FLOAT         = (1 << 3);
     }
 }
 
 bitflags::bitflags! {
+    /// Flags modifying the interpretation of color data in a [`Basic`] block.
+    ///
+    /// Controls whether color values have been pre-scaled by the alpha channel. Has no effect
+    /// if the format does not contain an alpha channel.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
     #[repr(transparent)]
     pub struct DataFormatFlags: u8 {
+        /// Color values are not premultiplied — they need to be scaled by alpha during blending.
+        ///
+        /// Not a flag itself, but an alias for when ALPHA_PREMULTIPLIED is not set.
         const STRAIGHT_ALPHA             = 0;
+        /// Color values have already been scaled by the alpha channel.
         const ALPHA_PREMULTIPLIED        = (1 << 0);
     }
 }

--- a/src/dfd.rs
+++ b/src/dfd.rs
@@ -13,7 +13,8 @@
 use core::num::NonZeroU8;
 
 pub use crate::enums::{ColorModel, ColorPrimaries, TransferFunction};
-use crate::{bytes_to_u32, read_bytes, read_u16, shift_and_mask_lower, ParseError};
+use crate::util::{bytes_to_u32, read_bytes, read_u16, shift_and_mask_lower};
+use crate::ParseError;
 
 pub struct Block<'data> {
     pub header: BlockHeader,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ extern crate std;
 pub mod dfd;
 mod enums;
 mod error;
+mod util;
 
 pub use crate::{
     enums::{Format, SupercompressionScheme},
@@ -229,7 +230,7 @@ impl<'data> Iterator for KeyValueDataIterator<'data> {
         let mut offset = 0;
 
         loop {
-            let length = bytes_to_u32(self.data, &mut offset).ok()?;
+            let length = util::bytes_to_u32(self.data, &mut offset).ok()?;
 
             let start_offset = offset;
 
@@ -397,37 +398,6 @@ impl LevelIndex {
 
         bytes
     }
-}
-
-fn read_bytes<const N: usize>(bytes: &[u8], offset: &mut usize) -> Result<[u8; N], ParseError> {
-    let v = bytes
-        .get(*offset..*offset + N)
-        .ok_or(ParseError::UnexpectedEnd)?
-        .try_into()
-        .unwrap();
-    *offset += N;
-    Ok(v)
-}
-
-fn read_u16(bytes: &[u8], offset: &mut usize) -> Result<u16, ParseError> {
-    let v = u16::from_le_bytes(read_bytes(bytes, offset)?);
-    Ok(v)
-}
-
-fn bytes_to_u32(bytes: &[u8], offset: &mut usize) -> Result<u32, ParseError> {
-    let v = u32::from_le_bytes(
-        bytes
-            .get(*offset..*offset + 4)
-            .ok_or(ParseError::UnexpectedEnd)?
-            .try_into()
-            .unwrap(),
-    );
-    *offset += 4;
-    Ok(v)
-}
-
-fn shift_and_mask_lower(shift: u32, mask: u32, value: u32) -> u32 {
-    (value >> shift) & ((1 << mask) - 1)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,15 +30,16 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+pub mod dfd;
 mod enums;
 mod error;
 
 pub use crate::{
-    enums::{ColorModel, ColorPrimaries, Format, SupercompressionScheme, TransferFunction},
+    enums::{Format, SupercompressionScheme},
     error::ParseError,
 };
 
-use core::{convert::TryInto, num::NonZeroU8};
+use core::convert::TryInto;
 
 /// Decodes KTX2 texture data
 pub struct Reader<Data: AsRef<[u8]>> {
@@ -158,7 +159,7 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         &self.input.as_ref()[start..end]
     }
 
-    pub fn dfd_blocks(&self) -> impl Iterator<Item = DfdBlock> {
+    pub fn dfd_blocks(&self) -> impl Iterator<Item = dfd::Block> {
         let header = self.header();
         let start = header.index.dfd_byte_offset as usize;
         // Bounds-checking previously performed in `new`
@@ -181,25 +182,28 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
     }
 }
 
-struct DfdBlockIterator<'data> {
+pub(crate) struct DfdBlockIterator<'data> {
     data: &'data [u8],
 }
 
 impl<'data> Iterator for DfdBlockIterator<'data> {
-    type Item = DfdBlock<'data>;
+    type Item = dfd::Block<'data>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.data.len() < DfdHeader::LENGTH {
+        if self.data.len() < dfd::BlockHeader::LENGTH {
             return None;
         }
-        DfdHeader::parse(&self.data[..DfdHeader::LENGTH]).map_or(None, |(header, descriptor_block_size)| {
-            if descriptor_block_size == 0 || self.data.len() < descriptor_block_size {
-                return None;
-            }
-            let data = &self.data[DfdHeader::LENGTH..descriptor_block_size];
-            self.data = &self.data[descriptor_block_size..];
-            Some(DfdBlock { header, data })
-        })
+        dfd::BlockHeader::parse(&self.data[..dfd::BlockHeader::LENGTH]).map_or(
+            None,
+            |(header, descriptor_block_size)| {
+                if descriptor_block_size == 0 || self.data.len() < descriptor_block_size {
+                    return None;
+                }
+                let data = &self.data[dfd::BlockHeader::LENGTH..descriptor_block_size];
+                self.data = &self.data[descriptor_block_size..];
+                Some(dfd::Block { header, data })
+            },
+        )
     }
 }
 
@@ -395,232 +399,6 @@ impl LevelIndex {
     }
 }
 
-bitflags::bitflags! {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    #[repr(transparent)]
-    pub struct ChannelTypeQualifiers: u8 {
-        const LINEAR        = (1 << 0);
-        const EXPONENT      = (1 << 1);
-        const SIGNED        = (1 << 2);
-        const FLOAT         = (1 << 3);
-    }
-}
-
-bitflags::bitflags! {
-    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-    #[repr(transparent)]
-    pub struct DataFormatFlags: u8 {
-        const STRAIGHT_ALPHA             = 0;
-        const ALPHA_PREMULTIPLIED        = (1 << 0);
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct DfdHeader {
-    pub vendor_id: u32,       //: 17;
-    pub descriptor_type: u32, //: 15;
-    pub version_number: u16,  //: 16;
-}
-
-impl DfdHeader {
-    pub const LENGTH: usize = 8;
-
-    pub const BASIC: Self = Self {
-        vendor_id: 0,
-        descriptor_type: 0,
-        version_number: 2,
-    };
-
-    pub fn as_bytes(&self, descriptor_block_size: u16) -> [u8; Self::LENGTH] {
-        let mut output = [0u8; Self::LENGTH];
-
-        let first_word = (self.vendor_id & ((1 << 17) - 1)) | (self.descriptor_type << 17);
-        output[0..4].copy_from_slice(&first_word.to_le_bytes());
-        output[4..6].copy_from_slice(&self.version_number.to_le_bytes());
-        output[6..8].copy_from_slice(&descriptor_block_size.to_le_bytes());
-
-        output
-    }
-
-    fn parse(bytes: &[u8]) -> Result<(Self, usize), ParseError> {
-        let mut offset = 0;
-
-        let v = bytes_to_u32(bytes, &mut offset)?;
-        let vendor_id = shift_and_mask_lower(0, 17, v);
-        let descriptor_type = shift_and_mask_lower(17, 15, v);
-
-        let version_number = read_u16(bytes, &mut offset)?;
-        let descriptor_block_size = read_u16(bytes, &mut offset)?;
-
-        Ok((
-            Self {
-                vendor_id,
-                descriptor_type,
-                version_number,
-            },
-            descriptor_block_size as usize,
-        ))
-    }
-}
-
-pub struct DfdBlock<'data> {
-    pub header: DfdHeader,
-    pub data: &'data [u8],
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct DfdBlockHeaderBasic {
-    /// None means Unspecified
-    pub color_model: Option<ColorModel>, //: 8;
-    /// None means Unspecified
-    pub color_primaries: Option<ColorPrimaries>, //: 8;
-    /// None means Unspecified
-    pub transfer_function: Option<TransferFunction>, //: 8;
-    pub flags: DataFormatFlags,                 //: 8;
-    pub texel_block_dimensions: [NonZeroU8; 4], //: 8 x 4;
-    pub bytes_planes: [u8; 8],                  //: 8 x 8;
-}
-
-impl DfdBlockHeaderBasic {
-    pub const LENGTH: usize = 16;
-
-    pub fn as_bytes(&self) -> [u8; Self::LENGTH] {
-        let mut bytes = [0u8; Self::LENGTH];
-
-        let color_model = self.color_model.map(|c| c.value()).unwrap_or(0);
-        let color_primaries = self.color_primaries.map(|c| c.value()).unwrap_or(0);
-        let transfer_function = self.transfer_function.map(|t| t.value()).unwrap_or(0);
-
-        let texel_block_dimensions = self.texel_block_dimensions.map(|dim| dim.get() - 1);
-
-        bytes[0] = color_model;
-        bytes[1] = color_primaries;
-        bytes[2] = transfer_function;
-        bytes[3] = self.flags.bits();
-        bytes[4..8].copy_from_slice(&texel_block_dimensions);
-        bytes[8..16].copy_from_slice(&self.bytes_planes);
-
-        bytes
-    }
-
-    pub fn from_bytes(bytes: &[u8; Self::LENGTH]) -> Result<Self, ParseError> {
-        let mut offset = 0;
-
-        let [model, primaries, transfer, flags] = read_bytes(bytes, &mut offset)?;
-        let texel_block_dimensions = read_bytes(bytes, &mut offset)?.map(|dim| NonZeroU8::new(dim + 1).unwrap());
-        let bytes_planes = read_bytes(bytes, &mut offset)?;
-
-        Ok(Self {
-            color_model: ColorModel::new(model),
-            color_primaries: ColorPrimaries::new(primaries),
-            transfer_function: TransferFunction::new(transfer),
-            flags: DataFormatFlags::from_bits_truncate(flags),
-            texel_block_dimensions,
-            bytes_planes,
-        })
-    }
-}
-
-pub struct DfdBlockBasic<'data> {
-    pub header: DfdBlockHeaderBasic,
-    sample_information: &'data [u8],
-}
-
-impl<'data> DfdBlockBasic<'data> {
-    pub fn parse(bytes: &'data [u8]) -> Result<Self, ParseError> {
-        let header_data = bytes
-            .get(0..DfdBlockHeaderBasic::LENGTH)
-            .ok_or(ParseError::UnexpectedEnd)?
-            .try_into()
-            .unwrap();
-        let header = DfdBlockHeaderBasic::from_bytes(header_data)?;
-
-        Ok(Self {
-            header,
-            sample_information: &bytes[DfdBlockHeaderBasic::LENGTH..],
-        })
-    }
-
-    pub fn sample_information(&self) -> impl Iterator<Item = SampleInformation> + 'data {
-        SampleInformationIterator {
-            data: self.sample_information,
-        }
-    }
-}
-
-struct SampleInformationIterator<'data> {
-    data: &'data [u8],
-}
-
-impl Iterator for SampleInformationIterator<'_> {
-    type Item = SampleInformation;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let bytes = self.data.get(0..SampleInformation::LENGTH)?.try_into().unwrap();
-        SampleInformation::from_bytes(&bytes).map_or(None, |sample_information| {
-            self.data = &self.data[SampleInformation::LENGTH..];
-            Some(sample_information)
-        })
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct SampleInformation {
-    pub bit_offset: u16,                                //: 16;
-    pub bit_length: NonZeroU8,                          //: 8;
-    pub channel_type: u8,                               //: 4;
-    pub channel_type_qualifiers: ChannelTypeQualifiers, //: 4;
-    pub sample_positions: [u8; 4],                      //: 8 x 4;
-    pub lower: u32,                                     //: 32;
-    pub upper: u32,                                     //: 32;
-}
-
-impl SampleInformation {
-    pub const LENGTH: usize = 16;
-
-    pub fn as_bytes(&self) -> [u8; Self::LENGTH] {
-        let mut bytes = [0u8; Self::LENGTH];
-
-        let channel_info = self.channel_type | (self.channel_type_qualifiers.bits() << 4);
-
-        bytes[0..2].copy_from_slice(&self.bit_offset.to_le_bytes());
-        bytes[2] = self.bit_length.get() - 1;
-        bytes[3] = channel_info;
-        bytes[4..8].copy_from_slice(&self.sample_positions);
-        bytes[8..12].copy_from_slice(&self.lower.to_le_bytes());
-        bytes[12..16].copy_from_slice(&self.upper.to_le_bytes());
-
-        bytes
-    }
-
-    pub fn from_bytes(bytes: &[u8; Self::LENGTH]) -> Result<Self, ParseError> {
-        let mut offset = 0;
-
-        let v = bytes_to_u32(bytes, &mut offset)?;
-        let bit_offset = shift_and_mask_lower(0, 16, v) as u16;
-        let bit_length = (shift_and_mask_lower(16, 8, v) as u8)
-            .checked_add(1)
-            .and_then(NonZeroU8::new)
-            .ok_or(ParseError::InvalidSampleBitLength)?;
-        let channel_type = shift_and_mask_lower(24, 4, v) as u8;
-        let channel_type_qualifiers = ChannelTypeQualifiers::from_bits_truncate(shift_and_mask_lower(28, 4, v) as u8);
-
-        let sample_positions = read_bytes(bytes, &mut offset)?;
-        let lower = bytes_to_u32(bytes, &mut offset)?;
-        let upper = bytes_to_u32(bytes, &mut offset)?;
-
-        Ok(Self {
-            bit_offset,
-            bit_length,
-            channel_type,
-            channel_type_qualifiers,
-            sample_positions,
-            lower,
-            upper,
-        })
-    }
-}
-
 fn read_bytes<const N: usize>(bytes: &[u8], offset: &mut usize) -> Result<[u8; N], ParseError> {
     let v = bytes
         .get(*offset..*offset + N)
@@ -655,61 +433,6 @@ fn shift_and_mask_lower(shift: u32, mask: u32, value: u32) -> u32 {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    fn to_nonzero<const N: usize>(input: [u8; N]) -> [NonZeroU8; N] {
-        input.map(|n| NonZeroU8::new(n).unwrap())
-    }
-
-    #[test]
-    fn basic_dfd_header_roundtrip() {
-        let header = DfdBlockHeaderBasic {
-            color_model: Some(ColorModel::LabSDA),
-            color_primaries: Some(ColorPrimaries::ACES),
-            transfer_function: Some(TransferFunction::ITU),
-            flags: DataFormatFlags::STRAIGHT_ALPHA,
-            texel_block_dimensions: to_nonzero([1, 2, 3, 4]),
-            bytes_planes: [5, 6, 7, 8, 9, 10, 11, 12],
-        };
-
-        let bytes = header.as_bytes();
-        let decoded = DfdBlockHeaderBasic::from_bytes(&bytes).unwrap();
-        assert_eq!(header, decoded);
-    }
-
-    #[test]
-    fn sample_information_roundtrip() {
-        let info = SampleInformation {
-            bit_offset: 234,
-            bit_length: NonZeroU8::new(123).unwrap(),
-            channel_type: 2,
-            channel_type_qualifiers: ChannelTypeQualifiers::LINEAR,
-            sample_positions: [1, 2, 3, 4],
-            lower: 1234,
-            upper: 4567,
-        };
-
-        let bytes = info.as_bytes();
-        let decoded = SampleInformation::from_bytes(&bytes).unwrap();
-
-        assert_eq!(info, decoded);
-    }
-
-    #[test]
-    fn sample_info_invalid_bit_length() {
-        let bytes = &[
-            0u8, 0,   // bit_offset
-            255, // bit_length
-            1,   // channel_type | channel_type_qualifiers
-            0, 0, 0, 0, // sample_positions
-            0, 0, 0, 0, // lower
-            255, 255, 255, 255, // upper
-        ];
-
-        assert!(matches!(
-            SampleInformation::from_bytes(bytes),
-            Err(ParseError::InvalidSampleBitLength)
-        ));
-    }
 
     #[test]
     #[allow(clippy::octal_escapes)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,8 @@
+//! Parsing utility functions.
+
 use crate::ParseError;
 
+/// Reads `N` bytes from `bytes` at the current `offset`, advancing `offset` by `N`.
 pub fn read_bytes<const N: usize>(bytes: &[u8], offset: &mut usize) -> Result<[u8; N], ParseError> {
     let v = bytes
         .get(*offset..*offset + N)
@@ -10,11 +13,13 @@ pub fn read_bytes<const N: usize>(bytes: &[u8], offset: &mut usize) -> Result<[u
     Ok(v)
 }
 
+/// Reads a little-endian `u16` from `bytes` at the current `offset`, advancing `offset` by 2.
 pub fn read_u16(bytes: &[u8], offset: &mut usize) -> Result<u16, ParseError> {
     let v = u16::from_le_bytes(read_bytes(bytes, offset)?);
     Ok(v)
 }
 
+/// Reads a little-endian `u32` from `bytes` at the current `offset`, advancing `offset` by 4.
 pub fn bytes_to_u32(bytes: &[u8], offset: &mut usize) -> Result<u32, ParseError> {
     let v = u32::from_le_bytes(
         bytes
@@ -27,6 +32,9 @@ pub fn bytes_to_u32(bytes: &[u8], offset: &mut usize) -> Result<u32, ParseError>
     Ok(v)
 }
 
+/// Right-shifts `value` by `shift` bits, then masks out all but the lower `mask` bits of the result.
+///
+/// This is the same operation as bitfield extraction in shading languages.
 pub fn shift_and_mask_lower(shift: u32, mask: u32, value: u32) -> u32 {
     (value >> shift) & ((1 << mask) - 1)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,32 @@
+use crate::ParseError;
+
+pub fn read_bytes<const N: usize>(bytes: &[u8], offset: &mut usize) -> Result<[u8; N], ParseError> {
+    let v = bytes
+        .get(*offset..*offset + N)
+        .ok_or(ParseError::UnexpectedEnd)?
+        .try_into()
+        .unwrap();
+    *offset += N;
+    Ok(v)
+}
+
+pub fn read_u16(bytes: &[u8], offset: &mut usize) -> Result<u16, ParseError> {
+    let v = u16::from_le_bytes(read_bytes(bytes, offset)?);
+    Ok(v)
+}
+
+pub fn bytes_to_u32(bytes: &[u8], offset: &mut usize) -> Result<u32, ParseError> {
+    let v = u32::from_le_bytes(
+        bytes
+            .get(*offset..*offset + 4)
+            .ok_or(ParseError::UnexpectedEnd)?
+            .try_into()
+            .unwrap(),
+    );
+    *offset += 4;
+    Ok(v)
+}
+
+pub fn shift_and_mask_lower(shift: u32, mask: u32, value: u32) -> u32 {
+    (value >> shift) & ((1 << mask) - 1)
+}


### PR DESCRIPTION
Each commit is standalone and does one transform. This should be rebase-merged.

Extracts dfd stuff into a public `dfd` module as we discussed. Also extracts utils to a private module.

Also adds docs to all the dfd stuff.... woof.