### PR TITLE
DFD Parsing Refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Per Keep a Changelog there are 6 main categories of changes:
   - `DataFormatFlags`
   - `SampleInformation`
   - `TransferFunction`
+- Added `dfd::Block` serialization: `serialized_length()`, `to_bytes()`, `to_vec()`, `parse()`
+- `dfd::Block` is now an owned enum (`Basic(Basic)` | `Unknown { header, data }`) instead of a borrowed struct
+- `dfd::BasicHeader` merged into `dfd::Basic`, which now owns its `sample_information: Vec<SampleInformation>` instead of providing a lazy iterator. `dfd::BasicHeader::LENGTH` is now `dfd::Basic::FIXED_LENGTH`
+- `Reader::dfd_blocks()` returns `&[dfd::Block]` instead of `impl Iterator<Item = dfd::Block<'_>>`
 
 ## v0.4.0
 

--- a/src/dfd.rs
+++ b/src/dfd.rs
@@ -139,8 +139,8 @@ impl BlockHeader {
         version_number: 2,
     };
 
-    /// Serializes the block header to bytes, using the provided `descriptor_block_size` for the
-    /// size of the [`Block::data`] field.
+    /// Serializes the block header to bytes. `descriptor_block_size` is the
+    /// total size of the containing [`Block`] (header + data).
     pub fn as_bytes(&self, descriptor_block_size: u16) -> [u8; Self::LENGTH] {
         let mut output = [0u8; Self::LENGTH];
 

--- a/src/dfd.rs
+++ b/src/dfd.rs
@@ -14,11 +14,9 @@
 //! and a data blob. The most common block type in KTX2 is the [`Basic`] block which contains information about
 //! texture-like data formats.
 //!
-//! This [`Basic`] block itself has a fixed size [`BasicHeader`] followed by a variable-length array of [`SampleInformation`]
-//! entries.
-//!
 //! [dfd-spec]: https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.inline.html
 
+use alloc::{vec, vec::Vec};
 use core::num::NonZeroU8;
 
 pub use crate::enums::{ColorModel, ColorPrimaries, TransferFunction};
@@ -28,15 +26,98 @@ use crate::ParseError;
 /// DFD block, containing a header and a data blob.
 ///
 /// The header describes the type of block, and the data blob contains the block's contents.
-pub struct Block<'data> {
-    pub header: BlockHeader,
-    pub data: &'data [u8],
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Block {
+    /// "Basic" DFD block. This is what most KTX2 files contain.
+    Basic(Basic),
+    /// DFD block type unknown to the ktx2 crate. Use the header
+    /// to determine if this is a relevant block type for your application.
+    Unknown { header: BlockHeader, data: Vec<u8> },
+}
+
+impl Block {
+    /// Parses a single [`Block`] from the start of `bytes`, returning the block and the number
+    /// of bytes consumed.
+    pub(crate) fn parse(bytes: &[u8]) -> Result<(Self, usize), ParseError> {
+        let (header, descriptor_block_size) = BlockHeader::from_bytes(
+            &bytes
+                .get(..BlockHeader::LENGTH)
+                .ok_or(ParseError::UnexpectedEnd)?
+                .try_into()
+                .unwrap(),
+        )?;
+
+        if descriptor_block_size == 0 {
+            return Err(ParseError::UnexpectedEnd);
+        }
+
+        let data = &bytes
+            .get(BlockHeader::LENGTH..descriptor_block_size)
+            .ok_or(ParseError::UnexpectedEnd)?;
+
+        let block = match header {
+            BlockHeader::BASIC => Block::Basic(Basic::parse(data)?),
+            _ => Block::Unknown {
+                header,
+                data: data.to_vec(),
+            },
+        };
+
+        Ok((block, descriptor_block_size))
+    }
+
+    /// Number of bytes the serialized form of this block will take up,
+    /// including the [`BlockHeader`].
+    pub fn serialized_length(&self) -> usize {
+        let data_length = match self {
+            Block::Basic(basic) => basic.serialized_length(),
+            Block::Unknown { data, .. } => data.len(),
+        };
+        BlockHeader::LENGTH + data_length
+    }
+
+    /// Serializes this block to a given slice of bytes. The slice must be at least
+    /// [`serialized_length`](Self::serialized_length) bytes long.
+    pub fn to_bytes(&self, output: &mut [u8]) {
+        assert!(
+            output.len() >= self.serialized_length(),
+            "Output buffer is too small to serialize Block: expected at least {} bytes, got {}",
+            self.serialized_length(),
+            output.len()
+        );
+
+        let descriptor_block_size = self.serialized_length() as u16;
+
+        // Serialize the header
+        let header = match self {
+            Block::Basic(_) => BlockHeader::BASIC,
+            Block::Unknown { header, .. } => *header,
+        };
+        output[..BlockHeader::LENGTH].copy_from_slice(&header.as_bytes(descriptor_block_size));
+
+        // Serialize the data
+        match self {
+            Block::Basic(basic) => {
+                basic.to_bytes(&mut output[BlockHeader::LENGTH..]);
+            }
+            Block::Unknown { data, .. } => {
+                output[BlockHeader::LENGTH..][..data.len()].copy_from_slice(data);
+            }
+        }
+    }
+
+    /// Serializes this block to a vector of bytes.
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut output = vec![0u8; self.serialized_length()];
+        self.to_bytes(&mut output);
+        output
+    }
 }
 
 /// DFD block header, containing what type and version of block.
 ///
 /// Implementations can skip blocks with unrecognized headers, allowing unknown data to be ignored.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BlockHeader {
     /// 17-bit organization identifier. `0` is Khronos. PCI SIG IDs use bits 0–15 with bit 16
     /// clear; other IDs are assigned by Khronos starting at 65536.
@@ -71,9 +152,9 @@ impl BlockHeader {
         output
     }
 
-    /// Parses a block header from the start of `bytes`, returning the header and the size
-    /// of the following [`Block::data`] field.
-    pub(crate) fn parse(bytes: &[u8]) -> Result<(Self, usize), ParseError> {
+    /// Deserializes a block header from bytes, returning the header and the size
+    /// of the containing [`Block`] (header + data).
+    pub(crate) fn from_bytes(bytes: &[u8; Self::LENGTH]) -> Result<(Self, usize), ParseError> {
         let mut offset = 0;
 
         let v = bytes_to_u32(bytes, &mut offset)?;
@@ -97,38 +178,8 @@ impl BlockHeader {
 /// "Basic" DFD block, containing information about texture-like data.
 ///
 /// This is the most common type of DFD block found in KTX2 files.
-pub struct Basic<'data> {
-    pub header: BasicHeader,
-    sample_information: &'data [u8],
-}
-
-impl<'data> Basic<'data> {
-    /// Parses a [`Basic`] block from the start of `bytes`.
-    pub fn parse(bytes: &'data [u8]) -> Result<Self, ParseError> {
-        let header_data = bytes
-            .get(0..BasicHeader::LENGTH)
-            .ok_or(ParseError::UnexpectedEnd)?
-            .try_into()
-            .unwrap();
-        let header = BasicHeader::from_bytes(header_data)?;
-
-        Ok(Self {
-            header,
-            sample_information: &bytes[BasicHeader::LENGTH..],
-        })
-    }
-
-    /// Iterator over the [`SampleInformation`] entries in this block.
-    pub fn sample_information(&self) -> impl Iterator<Item = SampleInformation> + 'data {
-        SampleInformationIterator {
-            data: self.sample_information,
-        }
-    }
-}
-
-/// Constant size data for a [`Basic`] DFD block.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct BasicHeader {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Basic {
     /// The set of color (or other data) channels which may be encoded within the data,
     /// though there is no requirement that all of the possible channels from the colorModel
     /// be present.
@@ -175,39 +226,33 @@ pub struct BasicHeader {
     ///
     /// [dfd-spec]: https://registry.khronos.org/DataFormat/specs/1.4/dataformat.1.4.inline.html#_emphasis_role_strong_emphasis_bytesplane_0_7_emphasis_emphasis
     pub bytes_planes: [u8; 8], //: 8 x 8;
+    /// Information about each "sample" within the data, describing how to interpret their bits of the data as color or other information.
+    pub sample_information: Vec<SampleInformation>,
 }
 
-impl BasicHeader {
-    /// Number of bytes in a BasicHeader.
-    pub const LENGTH: usize = 16;
+impl Basic {
+    /// Number of bytes in the constant-size prefix of a Basic block, before the variable-length sample information.
+    pub const FIXED_LENGTH: usize = 16;
 
-    /// Serializes the block header to bytes.
-    pub fn as_bytes(&self) -> [u8; Self::LENGTH] {
-        let mut bytes = [0u8; Self::LENGTH];
-
-        let color_model = self.color_model.map(|c| c.value()).unwrap_or(0);
-        let color_primaries = self.color_primaries.map(|c| c.value()).unwrap_or(0);
-        let transfer_function = self.transfer_function.map(|t| t.value()).unwrap_or(0);
-
-        let texel_block_dimensions = self.texel_block_dimensions.map(|dim| dim.get() - 1);
-
-        bytes[0] = color_model;
-        bytes[1] = color_primaries;
-        bytes[2] = transfer_function;
-        bytes[3] = self.flags.bits();
-        bytes[4..8].copy_from_slice(&texel_block_dimensions);
-        bytes[8..16].copy_from_slice(&self.bytes_planes);
-
-        bytes
-    }
-
-    /// Deserializes a block header from the given bytes.
-    pub fn from_bytes(bytes: &[u8; Self::LENGTH]) -> Result<Self, ParseError> {
+    /// Parses a [`Basic`] block from the start of `bytes`.
+    pub fn parse(bytes: &[u8]) -> Result<Self, ParseError> {
         let mut offset = 0;
 
         let [model, primaries, transfer, flags] = read_bytes(bytes, &mut offset)?;
         let texel_block_dimensions = read_bytes(bytes, &mut offset)?.map(|dim| NonZeroU8::new(dim + 1).unwrap());
         let bytes_planes = read_bytes(bytes, &mut offset)?;
+
+        let remaining_bytes = &bytes[Self::FIXED_LENGTH..];
+        // TODO: If MSRV is bumped to 1.88, use as_chunks::<SampleInformation::LENGTH>().
+        let iterator = remaining_bytes.chunks_exact(SampleInformation::LENGTH);
+
+        if !iterator.remainder().is_empty() {
+            return Err(ParseError::UnexpectedEnd);
+        }
+
+        let sample_information = iterator
+            .map(|chunk| SampleInformation::from_bytes(chunk.try_into().unwrap()))
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
             color_model: ColorModel::new(model),
@@ -216,23 +261,47 @@ impl BasicHeader {
             flags: DataFormatFlags::from_bits_truncate(flags),
             texel_block_dimensions,
             bytes_planes,
+            sample_information,
         })
     }
-}
 
-struct SampleInformationIterator<'data> {
-    data: &'data [u8],
-}
+    /// Number of bytes the serialized form of this block will take up.
+    pub fn serialized_length(&self) -> usize {
+        Self::FIXED_LENGTH + self.sample_information.len() * SampleInformation::LENGTH
+    }
 
-impl Iterator for SampleInformationIterator<'_> {
-    type Item = SampleInformation;
+    /// Serializes this block to a given slice of bytes. The slice must be at least [`serialized_length`](Self::serialized_length) bytes long.
+    pub fn to_bytes(&self, output: &mut [u8]) {
+        assert!(
+            output.len() >= self.serialized_length(),
+            "Output buffer is too small to serialize Basic block: expected at least {} bytes, got {}",
+            self.serialized_length(),
+            output.len()
+        );
 
-    fn next(&mut self) -> Option<Self::Item> {
-        let bytes = self.data.get(0..SampleInformation::LENGTH)?.try_into().unwrap();
-        SampleInformation::from_bytes(&bytes).map_or(None, |sample_information| {
-            self.data = &self.data[SampleInformation::LENGTH..];
-            Some(sample_information)
-        })
+        let color_model = self.color_model.map_or(0, |c| c.value());
+        let color_primaries = self.color_primaries.map_or(0, |c| c.value());
+        let transfer_function = self.transfer_function.map_or(0, |t| t.value());
+
+        let texel_block_dimensions = self.texel_block_dimensions.map(|dim| dim.get() - 1);
+
+        output[0] = color_model;
+        output[1] = color_primaries;
+        output[2] = transfer_function;
+        output[3] = self.flags.bits();
+        output[4..8].copy_from_slice(&texel_block_dimensions);
+        output[8..16].copy_from_slice(&self.bytes_planes);
+        for (i, sample) in self.sample_information.iter().enumerate() {
+            let start = Self::FIXED_LENGTH + i * SampleInformation::LENGTH;
+            output[start..][..SampleInformation::LENGTH].copy_from_slice(&sample.as_bytes());
+        }
+    }
+
+    /// Serializes this block to a vector of bytes.
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut output = vec![0u8; self.serialized_length()];
+        self.to_bytes(&mut output);
+        output
     }
 }
 
@@ -414,18 +483,19 @@ mod tests {
 
     #[test]
     fn basic_dfd_header_roundtrip() {
-        let header = BasicHeader {
+        let basic = Basic {
             color_model: Some(ColorModel::LabSDA),
             color_primaries: Some(ColorPrimaries::ACES),
             transfer_function: Some(TransferFunction::ITU),
             flags: DataFormatFlags::STRAIGHT_ALPHA,
             texel_block_dimensions: to_nonzero([1, 2, 3, 4]),
             bytes_planes: [5, 6, 7, 8, 9, 10, 11, 12],
+            sample_information: vec![],
         };
 
-        let bytes = header.as_bytes();
-        let decoded = BasicHeader::from_bytes(&bytes).unwrap();
-        assert_eq!(header, decoded);
+        let bytes = basic.to_vec();
+        let decoded = Basic::parse(&bytes).unwrap();
+        assert_eq!(basic, decoded);
     }
 
     #[test]

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -4,7 +4,7 @@ use core::{
 };
 
 macro_rules! pseudo_enum {
-    ($(#[$attr:meta])* $container:ident($prim:ident) $name:ident { $($case:ident = $value:literal,)* }) => {
+    ($(#[$attr:meta])* $container:ident($prim:ident) $name:ident { $($(#[$variant_attr:meta])* $case:ident = $value:literal,)* }) => {
         $(#[$attr])*
         #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
         pub struct $name($container);
@@ -20,6 +20,7 @@ macro_rules! pseudo_enum {
             }
 
             $(
+                $(#[$variant_attr])*
                 pub const $case: Self = Self(unsafe { $container::new_unchecked($value) });
             )*
         }
@@ -40,7 +41,15 @@ macro_rules! pseudo_enum {
 }
 
 pseudo_enum! {
-    /// Known texture formats
+    /// Vulkan `VkFormat` values for the texture's texel format.
+    ///
+    /// Wraps a non-zero `u32`. A value of `0` (`VK_FORMAT_UNDEFINED`) is
+    /// represented as `None` at the [`Header`](crate::Header) level, used
+    /// for Basis Universal and other supercompressed universal formats
+    /// where the actual GPU format is chosen at transcode time.
+    ///
+    /// Unknown non-zero format values are preserved — use [`value()`](Self::value)
+    /// to get the raw `u32` for passing to Vulkan.
     ///
     /// Intentionally omitted formats:
     /// - (scaled) *_USCALED/*_SSCALED: prohibited by KTX2. They are intended
@@ -330,15 +339,30 @@ pseudo_enum! {
 }
 
 pseudo_enum! {
-    /// Known supercompression schemes
+    /// Supercompression applied to mip level data.
+    ///
+    /// `None` (raw value `0`) at the [`Header`](crate::Header) level means
+    /// no supercompression — level data is ready to use directly.
+    ///
+    /// Vendor-specific schemes use IDs `>= 0x10000`.
     NonZeroU32(u32) SupercompressionScheme {
+        /// Basis Universal LZ. Level data must be transcoded, not just
+        /// decompressed. Global data section contains codebooks.
+        /// [`Level::uncompressed_byte_length`](crate::Level::uncompressed_byte_length)
+        /// will be `0`.
         BasisLZ = 1,
+        /// Zstandard (zstd). Decompress each level independently.
         Zstandard = 2,
+        /// ZLIB (deflate). Decompress each level independently.
         ZLIB = 3,
     }
 }
 
 pseudo_enum! {
+    /// Color model from the Khronos Data Format specification.
+    ///
+    /// `None` (raw value `0`) means unspecified. Values 128+ are
+    /// compressed-format models (BC, ETC, ASTC, etc.).
     NonZeroU8(u8) ColorModel {
         RGBSDA = 1,
         YUVSDA = 2,
@@ -373,6 +397,10 @@ pseudo_enum! {
 }
 
 pseudo_enum! {
+    /// Color primaries from the Khronos Data Format specification.
+    ///
+    /// `None` (raw value `0`) means unspecified. [`BT709`](Self::BT709) is
+    /// the most common value (sRGB / Rec. 709).
     NonZeroU8(u8) ColorPrimaries {
         BT709 = 1,
         BT601EBU = 2,
@@ -389,6 +417,10 @@ pseudo_enum! {
 }
 
 pseudo_enum! {
+    /// Transfer function (OETF/EOTF) from the Khronos Data Format specification.
+    ///
+    /// `None` (raw value `0`) means unspecified. [`SRGB`](Self::SRGB) and
+    /// [`Linear`](Self::Linear) are the most common values for game textures.
     NonZeroU8(u8) TransferFunction {
         Linear = 1,
         SRGB = 2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,13 @@ pub use crate::{
 use alloc::vec::Vec;
 use core::convert::TryInto;
 
-/// Decodes KTX2 texture data
+/// Parses and validates a KTX2 texture container from an in-memory buffer.
+///
+/// All validation (magic bytes, bounds checks, DFD integrity, level index) is
+/// performed eagerly in [`Reader::new`]. Subsequent accessors are infallible.
+///
+/// `Data` can be any type that derefs to `[u8]` — `&[u8]`, `Vec<u8>`,
+/// `Arc<[u8]>`, etc.
 pub struct Reader<Data: AsRef<[u8]>> {
     input: Data,
     header: Header,
@@ -53,7 +59,10 @@ pub struct Reader<Data: AsRef<[u8]>> {
 }
 
 impl<Data: AsRef<[u8]>> Reader<Data> {
-    /// Decode KTX2 data from `input`
+    /// Parse and validate a KTX2 buffer.
+    ///
+    /// Validates the header magic, all section bounds, the DFD, and the level
+    /// index. Returns [`ParseError`] on any structural problem.
     pub fn new(input: Data) -> Result<Self, ParseError> {
         let header_data = input
             .as_ref()
@@ -125,7 +134,8 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         Ok(result)
     }
 
-    /// Parses the Data Format Descriptor section into `self.dfd_blocks`.
+    /// Eagerly parses all DFD blocks from the DFD section into `self.dfd_blocks`.
+    /// Fails if the section contains a partial or malformed block.
     fn parse_dfd(&mut self) -> ParseResult<()> {
         let dfd_start = self.header.index.dfd_byte_offset as usize;
         let dfd_end = (self.header.index.dfd_byte_offset + self.header.index.dfd_byte_length) as usize;
@@ -145,7 +155,8 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         Ok(())
     }
 
-    /// Parses the level index table immediately following the header.
+    /// Parses the level index table that immediately follows the 80-byte header.
+    /// Each entry is 24 bytes. Used internally; prefer [`levels`](Self::levels) for data access.
     fn level_index(&self) -> ParseResult<impl ExactSizeIterator<Item = LevelIndex> + '_> {
         let level_count = self.header().level_count.max(1) as usize;
 
@@ -167,17 +178,19 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         }))
     }
 
-    /// Access underlying raw bytes
+    /// The raw KTX2 file bytes backing this reader.
     pub fn data(&self) -> &[u8] {
         self.input.as_ref()
     }
 
-    /// Container-level metadata
+    /// Container-level metadata (dimensions, format, compression, etc.).
     pub fn header(&self) -> Header {
         self.header
     }
 
-    /// Iterator over the texture's mip levels
+    /// Iterator over the texture's mip levels, ordered largest to smallest
+    /// (level 0 first, level *N-1* last). Each [`Level`] contains the raw
+    /// (possibly supercompressed) bytes for that level.
     pub fn levels(&self) -> impl ExactSizeIterator<Item = Level> + '_ {
         self.level_index().unwrap().map(move |level| Level {
             // Bounds-checking previously performed in `new`
@@ -186,6 +199,9 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         })
     }
 
+    /// Supercompression Global Data (SGD) section. Currently only used by
+    /// BasisLZ (scheme 1) for codebooks and image descriptors. Empty for
+    /// other schemes.
     pub fn supercompression_global_data(&self) -> &[u8] {
         let header = self.header();
         let start = header.index.sgd_byte_offset as usize;
@@ -194,12 +210,22 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         &self.input.as_ref()[start..end]
     }
 
-    /// Iterator over the DFD blocks in the file.
+    /// The Data Format Descriptor blocks. Most KTX2 files contain exactly
+    /// one [`dfd::Block::Basic`] block. Use this to inspect color model,
+    /// transfer function, primaries, and per-sample layout.
     pub fn dfd_blocks(&self) -> &[dfd::Block] {
         &self.dfd_blocks
     }
 
-    /// Iterator over the key-value pairs
+    /// Iterator over key/value metadata pairs. Keys are UTF-8 strings;
+    /// values are raw bytes (often NUL-terminated UTF-8, but not always).
+    ///
+    /// # Standard Keys
+    ///
+    /// The KTX specification defines a number of standard keys. Most commonly,
+    /// the `KTXwriter` key is used to indicate the tool that wrote the file.
+    ///
+    /// For a full list of standard keys, see the [KTX specification](https://github.khronos.org/KTX-Specification/ktxspec.v2.html#_keyvalue_data).
     pub fn key_value_data(&self) -> KeyValueDataIterator {
         let header = self.header();
 
@@ -211,16 +237,21 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
     }
 }
 
-/// An iterator that parses the key-value pairs in the KTX2 file.
+/// Iterator over KTX2 key/value metadata pairs.
+///
+/// Each item is `(key, value)` where `key` is a UTF-8 string and `value` is
+/// raw bytes (often UTF-8, but not guaranteed). Malformed entries are silently
+/// skipped. Prefer [`Reader::key_value_data`] over constructing this directly.
 pub struct KeyValueDataIterator<'data> {
     data: &'data [u8],
 }
 
 impl<'data> KeyValueDataIterator<'data> {
-    /// Create a new iterator from the key-value data section of the KTX2 file.
+    /// Create a new iterator from the raw key/value data section bytes.
     ///
-    /// From the start of the file, this is a slice between [`Index::kvd_byte_offset`]
-    /// and [`Index::kvd_byte_offset`] + [`Index::kvd_byte_length`].
+    /// The slice should span from [`Index::kvd_byte_offset`] to
+    /// `kvd_byte_offset + kvd_byte_length` relative to the start of the file.
+    /// Prefer [`Reader::key_value_data`] which handles this for you.
     pub fn new(data: &'data [u8]) -> Self {
         Self { data }
     }
@@ -272,43 +303,82 @@ impl<'data> Iterator for KeyValueDataIterator<'data> {
     }
 }
 
-/// Identifier, expected in start of input texture data.
-const KTX2_MAGIC: [u8; 12] = [0xAB, 0x4B, 0x54, 0x58, 0x20, 0x32, 0x30, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A];
+/// 12-byte file identifier: `«KTX 20»\r\n\x1A\n`. Must appear at offset 0.
+pub const MAGIC: [u8; 12] = [0xAB, 0x4B, 0x54, 0x58, 0x20, 0x32, 0x30, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A];
 
 /// Result of parsing data operation.
 type ParseResult<T> = Result<T, ParseError>;
 
-/// Container-level metadata
+/// Container-level metadata (dimensions, format, layout) from the 80-byte KTX2 file header.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct Header {
+    /// Vulkan `VkFormat` enum value. `None` means `VK_FORMAT_UNDEFINED`,
+    /// used for supercompressed universal formats (e.g. Basis Universal)
+    /// where the actual format is determined at transcode time.
     pub format: Option<Format>,
+    /// Size in bytes of the data type used for GPU upload, for endian conversion
+    /// on big-endian systems (all image data in KTX2 is little-endian).
+    ///
+    /// Must be `1` when `format` is `None` (VK_FORMAT_UNDEFINED) or for
+    /// block-compressed formats (`_BLOCK` suffix). For packed formats
+    /// (`_PACKxx`), equals the byte size of the packed unit `xx / 8`
+    /// (e.g. `4` for `_PACK32`). For unpacked formats, equals the byte size
+    /// of a single component (e.g. `2` for `R16G16B16_UNORM`). For combined
+    /// depth/stencil: `2` for `D16_UNORM_S8_UINT`, `4` for all others.
     pub type_size: u32,
+    /// Texture width in texels. Always non-zero.
     pub pixel_width: u32,
+    /// Texture height in texels. `0` for 1D textures.
     pub pixel_height: u32,
+    /// Texture depth in texels. `0` for non-3D textures.
     pub pixel_depth: u32,
+    /// Number of array layers. `0` means a non-array texture (1 implicit
+    /// layer). Use `layer_count.max(1)` when allocating storage.
     pub layer_count: u32,
+    /// Number of cubemap faces. `6` for cubemaps, `1` otherwise.
     pub face_count: u32,
+    /// Number of mip levels. `0` means the full mip chain should be
+    /// generated from level 0 by the application if needed.
+    /// Use `level_count.max(1)` when iterating stored levels.
     pub level_count: u32,
+    /// Compression applied to mip level data. `None` means uncompressed.
+    /// When set, each [`Level::data`] must be decompressed before use.
     pub supercompression_scheme: Option<SupercompressionScheme>,
+    /// Raw byte offsets/lengths for the DFD, KVD, and SGD sections.
+    /// For most use cases, prefer [`Reader::dfd_blocks`],
+    /// [`Reader::key_value_data`], and
+    /// [`Reader::supercompression_global_data`] instead.
     pub index: Index,
 }
 
-/// An index giving the byte offsets from the start of the file and byte sizes of the various sections of the KTX2 file.
+/// Byte offsets and lengths (from start of file) for the DFD, KVD, and SGD sections.
+///
+/// You typically don't need these directly — use [`Reader::dfd_blocks`],
+/// [`Reader::key_value_data`], and [`Reader::supercompression_global_data`] instead.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct Index {
+    /// Byte offset of the Data Format Descriptor section.
     pub dfd_byte_offset: u32,
+    /// Byte length of the Data Format Descriptor section.
     pub dfd_byte_length: u32,
+    /// Byte offset of the Key/Value Data section.
     pub kvd_byte_offset: u32,
+    /// Byte length of the Key/Value Data section. `0` if absent.
     pub kvd_byte_length: u32,
+    /// Byte offset of the Supercompression Global Data section.
     pub sgd_byte_offset: u64,
+    /// Byte length of the Supercompression Global Data section. `0` if absent.
     pub sgd_byte_length: u64,
 }
 
 impl Header {
+    /// Size of the KTX2 header in bytes (12-byte magic + 68-byte fields).
     pub const LENGTH: usize = 80;
 
+    /// Decode a header from exactly 80 bytes. Validates the magic bytes and
+    /// rejects zero `pixel_width` or zero `face_count`.
     pub fn from_bytes(data: &[u8; Self::LENGTH]) -> ParseResult<Self> {
-        if !data.starts_with(&KTX2_MAGIC) {
+        if !data.starts_with(&MAGIC) {
             return Err(ParseError::BadMagic);
         }
 
@@ -342,13 +412,14 @@ impl Header {
         Ok(header)
     }
 
+    /// Serialize this header back to 80 bytes (including magic).
     pub fn as_bytes(&self) -> [u8; Self::LENGTH] {
         let mut bytes = [0; Self::LENGTH];
 
         let format = self.format.map(|format| format.value()).unwrap_or(0);
         let supercompression_scheme = self.supercompression_scheme.map(|scheme| scheme.value()).unwrap_or(0);
 
-        bytes[0..12].copy_from_slice(&KTX2_MAGIC);
+        bytes[0..12].copy_from_slice(&MAGIC);
         bytes[12..16].copy_from_slice(&format.to_le_bytes()[..]);
         bytes[16..20].copy_from_slice(&self.type_size.to_le_bytes()[..]);
         bytes[20..24].copy_from_slice(&self.pixel_width.to_le_bytes()[..]);
@@ -369,21 +440,42 @@ impl Header {
     }
 }
 
+/// A single mip level's data, returned by [`Reader::levels`].
+///
+/// If [`Header::supercompression_scheme`] is `Some`, `data` is still
+/// compressed — decompress it (e.g. via zstd/zlib) before interpreting
+/// the texels according to [`Header::format`].
 pub struct Level<'a> {
+    /// Raw (possibly supercompressed) bytes for this mip level.
+    ///
+    /// After decompression, the data is laid out as:
+    /// `layer → face → z-slice → row → texel/block`, where layers come
+    /// from `layer_count` (1 if 0), faces from `face_count` (6 for
+    /// cubemaps), and z-slices from `pixel_depth` (for 3D textures).
     pub data: &'a [u8],
+    /// Size of `data` after decompression. Equals `data.len()` when no
+    /// supercompression is applied. `0` for BasisLZ (transcode instead).
     pub uncompressed_byte_length: u64,
 }
 
+/// Offsets dictating the location of a [`Level`] within a file.
+///
+/// This is mainly useful for writing or low-level manipulation. Prefer [`Reader::levels`] for data access.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct LevelIndex {
+    /// Byte offset from the start of the file to this level's data.
     pub byte_offset: u64,
+    /// Byte length of the (possibly supercompressed) level data.
     pub byte_length: u64,
+    /// Byte length after decompression. `0` for BasisLZ.
     pub uncompressed_byte_length: u64,
 }
 
 impl LevelIndex {
+    /// Size of one level index entry in bytes.
     pub const LENGTH: usize = 24;
 
+    /// Decode a level index entry from 24 little-endian bytes.
     pub fn from_bytes(data: &[u8; Self::LENGTH]) -> Self {
         Self {
             byte_offset: u64::from_le_bytes(data[0..8].try_into().unwrap()),
@@ -392,6 +484,7 @@ impl LevelIndex {
         }
     }
 
+    /// Serialize this entry back to 24 little-endian bytes.
     pub fn as_bytes(&self) -> [u8; Self::LENGTH] {
         let mut bytes = [0; Self::LENGTH];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@
 
 #![no_std]
 
+extern crate alloc;
+
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -40,21 +42,25 @@ pub use crate::{
     error::ParseError,
 };
 
+use alloc::vec::Vec;
 use core::convert::TryInto;
 
 /// Decodes KTX2 texture data
 pub struct Reader<Data: AsRef<[u8]>> {
     input: Data,
     header: Header,
+    dfd_blocks: Vec<dfd::Block>,
 }
 
 impl<Data: AsRef<[u8]>> Reader<Data> {
     /// Decode KTX2 data from `input`
     pub fn new(input: Data) -> Result<Self, ParseError> {
-        if input.as_ref().len() < Header::LENGTH {
-            return Err(ParseError::UnexpectedEnd);
-        }
-        let header_data = input.as_ref()[0..Header::LENGTH].try_into().unwrap();
+        let header_data = input
+            .as_ref()
+            .get(0..Header::LENGTH)
+            .ok_or(ParseError::UnexpectedEnd)?
+            .try_into()
+            .unwrap();
         let header = Header::from_bytes(header_data)?;
 
         // Check DFD bounds
@@ -94,8 +100,15 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
             return Err(ParseError::UnexpectedEnd);
         }
 
-        let result = Self { input, header };
-        let index = result.level_index()?; // Check index integrity
+        let mut result = Self {
+            input,
+            header,
+            // 1 is the most likely length, as 99.99% of KTX2 files have exactly 1 DFD block.
+            dfd_blocks: Vec::with_capacity(1),
+        };
+        result.parse_dfd()?;
+        // Creating the iterator validates the integrity of the level index.
+        let index = result.level_index()?;
 
         // Check level data bounds
         for level in index {
@@ -112,6 +125,27 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         Ok(result)
     }
 
+    /// Parses the Data Format Descriptor section into `self.dfd_blocks`.
+    fn parse_dfd(&mut self) -> ParseResult<()> {
+        let dfd_start = self.header.index.dfd_byte_offset as usize;
+        let dfd_end = (self.header.index.dfd_byte_offset + self.header.index.dfd_byte_length) as usize;
+        // Skip the 4-byte DFD total length field
+        let mut data = &self.input.as_ref()[dfd_start + 4..dfd_end];
+
+        // If we ever encounter a partial DFD, we want to throw an error,
+        // not silently ignore the rest of the DFD data. We should end up consuming
+        // all of the DFD data. If we end up with unconsumed DFD data, we let
+        // dfd::Block::parse throw an error.
+        while !data.is_empty() {
+            let (block, consumed) = dfd::Block::parse(data)?;
+            self.dfd_blocks.push(block);
+            data = &data[consumed..];
+        }
+
+        Ok(())
+    }
+
+    /// Parses the level index table immediately following the header.
     fn level_index(&self) -> ParseResult<impl ExactSizeIterator<Item = LevelIndex> + '_> {
         let level_count = self.header().level_count.max(1) as usize;
 
@@ -160,15 +194,9 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         &self.input.as_ref()[start..end]
     }
 
-    pub fn dfd_blocks(&self) -> impl Iterator<Item = dfd::Block> {
-        let header = self.header();
-        let start = header.index.dfd_byte_offset as usize;
-        // Bounds-checking previously performed in `new`
-        let end = (header.index.dfd_byte_offset + header.index.dfd_byte_length) as usize;
-        DfdBlockIterator {
-            // start + 4 to skip the data format descriptors total length
-            data: &self.input.as_ref()[start + 4..end],
-        }
+    /// Iterator over the DFD blocks in the file.
+    pub fn dfd_blocks(&self) -> &[dfd::Block] {
+        &self.dfd_blocks
     }
 
     /// Iterator over the key-value pairs
@@ -180,31 +208,6 @@ impl<Data: AsRef<[u8]>> Reader<Data> {
         let end = (header.index.kvd_byte_offset + header.index.kvd_byte_length) as usize;
 
         KeyValueDataIterator::new(&self.input.as_ref()[start..end])
-    }
-}
-
-pub(crate) struct DfdBlockIterator<'data> {
-    data: &'data [u8],
-}
-
-impl<'data> Iterator for DfdBlockIterator<'data> {
-    type Item = dfd::Block<'data>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.data.len() < dfd::BlockHeader::LENGTH {
-            return None;
-        }
-        dfd::BlockHeader::parse(&self.data[..dfd::BlockHeader::LENGTH]).map_or(
-            None,
-            |(header, descriptor_block_size)| {
-                if descriptor_block_size == 0 || self.data.len() < descriptor_block_size {
-                    return None;
-                }
-                let data = &self.data[dfd::BlockHeader::LENGTH..descriptor_block_size];
-                self.data = &self.data[descriptor_block_size..];
-                Some(dfd::Block { header, data })
-            },
-        )
     }
 }
 


### PR DESCRIPTION
Stacked on #38 

This applies the discussed transforms to the DFD parsing stack. They now store parsed vectors as opposed to unparsed references.

Additionally I have done another documentation pass across the board.

All commits standalone, can be rebased.